### PR TITLE
Groupchat feature

### DIFF
--- a/app/src/main/java/com/example/classseek/data/ChatRepository.kt
+++ b/app/src/main/java/com/example/classseek/data/ChatRepository.kt
@@ -28,6 +28,8 @@ class ChatRepository(private val db: FirebaseFirestore) {
     private val chatsRef = db.collection("chats")
     private val dmThreadsRef = db.collection("dmThreads")
 
+    private val groupThreadsRef = db.collection("groupThreads")
+
     /**
      * Open an existing DM between uidA and uidB, or create it if absent.
      * Returns the chatId.
@@ -89,6 +91,83 @@ class ChatRepository(private val db: FirebaseFirestore) {
         }.await()
 
         return newChatRef.id
+    }
+
+    /**
+    Possibly temporary until real user accounts are created.
+     */
+    private fun buildGroupKey(memberIds: List<String>): String {
+        return memberIds
+            .distinct()
+            .sorted()
+            .joinToString("_")
+    }
+
+    suspend fun openOrCreateGroupChat(
+        createdBy: String,
+        memberIds: List<String>,
+        title: String,
+        photoURL: String? = null
+    ): String {
+        require(memberIds.isNotEmpty()) { "memberIds cannot be empty" }
+
+        val uniqueMembers = memberIds.distinct()
+        require(uniqueMembers.contains(createdBy)) { "memberIds should include createdBy" }
+
+        val groupKey = buildGroupKey(uniqueMembers)
+        val groupThreadRef = groupThreadsRef.document(groupKey)
+
+        val existing = groupThreadRef.get().await()
+        if (existing.exists()) {
+            val chatId = existing.getString("chatId")
+            if (!chatId.isNullOrBlank()) {
+                val myMemberRef = chatsRef.document(chatId)
+                    .collection("members")
+                    .document(createdBy)
+
+                myMemberRef.update("hidden", false).await()
+                return chatId
+            }
+        }
+
+        val chatRef = chatsRef.document()
+
+        db.runTransaction { tx ->
+            val now = Timestamp.now()
+
+            tx.set(chatRef, mapOf(
+                "type" to "group",
+                "title" to title,
+                "memberIds" to uniqueMembers,
+                "createdAt" to now,
+                "createdBy" to createdBy,
+                "memberCount" to uniqueMembers.size,
+                "photoURL" to (photoURL ?: ""),
+                "lastMessageAt" to null,
+                "lastMessageText" to null,
+                "lastMessageSenderId" to null
+            ))
+
+            uniqueMembers.forEach { uid ->
+                val role = if (uid == createdBy) "owner" else "member"
+                val memberRef = chatRef.collection("members").document(uid)
+                tx.set(memberRef, mapOf(
+                    "role" to role,
+                    "joinedAt" to now,
+                    "lastReadAt" to null,
+                    "hidden" to false
+                ))
+            }
+
+            tx.set(groupThreadRef, mapOf(
+                "chatId" to chatRef.id,
+                "groupKey" to groupKey,
+                "memberIds" to uniqueMembers,
+                "createdAt" to now
+            ))
+        }.await()
+
+        return chatRef.id
     }
 
     /**

--- a/app/src/main/java/com/example/classseek/data/ChatRepository.kt
+++ b/app/src/main/java/com/example/classseek/data/ChatRepository.kt
@@ -7,6 +7,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
 import com.google.firebase.firestore.MetadataChanges
 import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.SetOptions
 import kotlinx.coroutines.tasks.await
 import java.util.UUID
 
@@ -48,7 +49,7 @@ class ChatRepository(private val db: FirebaseFirestore) {
      */
     suspend fun openOrCreateDm(uidA: String, uidB: String, title: String?): String {
         val (a, b) = listOf(uidA, uidB).sorted()
-        val dmKey = "${a}_$b"
+        val dmKey = "${a}_${b}"
         val dmDocRef = dmThreadsRef.document(dmKey)
 
         val existing = dmDocRef.get().await()
@@ -262,7 +263,7 @@ class ChatRepository(private val db: FirebaseFirestore) {
 
     /**
      * Send a text message to a chat.
-     * Writes message + updates chat summary in one batch.
+     * Returns the exact messageId so the UI can scroll to the exact message sent.
      *
      * IMPORTANT: Updating each member's inbox/unread count is best done in Cloud Functions.
      */
@@ -271,7 +272,7 @@ class ChatRepository(private val db: FirebaseFirestore) {
         senderId: String,
         text: String,
         replyToMessageId: String? = null
-    ) {
+    ): String {
         val messageId = UUID.randomUUID().toString()
 
         val chatRef = chatsRef.document(chatId)
@@ -311,16 +312,21 @@ class ChatRepository(private val db: FirebaseFirestore) {
                     "lastMessageText" to text,
                     "lastMessageAt" to FieldValue.serverTimestamp()
                 ),
-                com.google.firebase.firestore.SetOptions.merge()
+                SetOptions.merge()
             )
         }
 
         batch.commit().await()
+        return messageId
     }
 
     /**
      * Listen to recent messages in realtime for chat logs.
      * Returns a ListenerRegistration; call remove() when the screen is disposed.
+     *
+     * Firestore already returns these ordered by createdAt DESC.
+     * We preserve snapshot order in the UI instead of re-sorting by hasPendingWrites,
+     * because re-sorting by metadata can make messages jump around.
      */
     fun listenMessagesRealtime(
         chatId: String,

--- a/app/src/main/java/com/example/classseek/data/ChatRepository.kt
+++ b/app/src/main/java/com/example/classseek/data/ChatRepository.kt
@@ -244,4 +244,9 @@ class ChatRepository(private val db: FirebaseFirestore) {
         memberRef.update("hidden", true).await()
     }
 
+    suspend fun getChatTitle(chatId: String): String {
+        val doc = chatsRef.document(chatId).get().await()
+        return doc.getString("title") ?: "Chat"
+    }
+
 }

--- a/app/src/main/java/com/example/classseek/data/ChatRepository.kt
+++ b/app/src/main/java/com/example/classseek/data/ChatRepository.kt
@@ -49,12 +49,6 @@ class ChatRepository(private val db: FirebaseFirestore) {
             val chatId = existing.getString("chatId")
 
             if (!chatId.isNullOrBlank()) {
-
-                /** val myMemberRef = chatsRef.document(chatId)
-                    .collection("members")
-                    .document(uidA)
-                */
-
                 inboxRef(uidA,chatId).update("hidden", false).await()
                 return chatId
             }
@@ -143,13 +137,6 @@ class ChatRepository(private val db: FirebaseFirestore) {
         if (existing.exists()) {
             val chatId = existing.getString("chatId")
             if (!chatId.isNullOrBlank()) {
-
-                /**
-                val myMemberRef = chatsRef.document(chatId)
-                    .collection("members")
-                    .document(createdBy)
-                */
-
                 inboxRef(createdBy, chatId).update("hidden", false).await()
                 return chatId
             }
@@ -388,13 +375,6 @@ class ChatRepository(private val db: FirebaseFirestore) {
      * hides chats from users without deleting them from database
      */
     suspend fun hideChatForUser(chatId: String, myUid: String) {
-
-        /**
-        val memberRef = chatsRef.document(chatId)
-            .collection("members")
-            .document(myUid)
-        */
-
         inboxRef(myUid,chatId).update("hidden", true).await()
     }
 

--- a/app/src/main/java/com/example/classseek/data/ChatRepository.kt
+++ b/app/src/main/java/com/example/classseek/data/ChatRepository.kt
@@ -30,6 +30,8 @@ class ChatRepository(private val db: FirebaseFirestore) {
 
     private val groupThreadsRef = db.collection("groupThreads")
 
+    private val usersRef = db.collection("users")
+
     /**
      * Open an existing DM between uidA and uidB, or create it if absent.
      * Returns the chatId.
@@ -47,11 +49,13 @@ class ChatRepository(private val db: FirebaseFirestore) {
             val chatId = existing.getString("chatId")
 
             if (!chatId.isNullOrBlank()) {
-                val myMemberRef = chatsRef.document(chatId)
+
+                /** val myMemberRef = chatsRef.document(chatId)
                     .collection("members")
                     .document(uidA)
+                */
 
-                myMemberRef.update("hidden", false).await()
+                inboxRef(uidA,chatId).update("hidden", false).await()
                 return chatId
             }
         }
@@ -81,6 +85,24 @@ class ChatRepository(private val db: FirebaseFirestore) {
 
             tx.set(memberARef, mapOf("role" to "member", "joinedAt" to now, "lastReadAt" to null))
             tx.set(memberBRef, mapOf("role" to "member", "joinedAt" to now, "lastReadAt" to null))
+
+            tx.set(inboxRef(a, newChatRef.id), mapOf(
+                "chatId" to newChatRef.id,
+                "title" to finalTitle,
+                "type" to "dm",
+                "lastMessageText" to null,
+                "lastMessageAt" to null,
+                "hidden" to false
+            ))
+
+            tx.set(inboxRef(b, newChatRef.id), mapOf(
+                "chatId" to newChatRef.id,
+                "title" to finalTitle,
+                "type" to "dm",
+                "lastMessageText" to null,
+                "lastMessageAt" to null,
+                "hidden" to false
+            ))
 
             tx.set(dmDocRef, mapOf(
                 "chatId" to newChatRef.id,
@@ -121,11 +143,14 @@ class ChatRepository(private val db: FirebaseFirestore) {
         if (existing.exists()) {
             val chatId = existing.getString("chatId")
             if (!chatId.isNullOrBlank()) {
+
+                /**
                 val myMemberRef = chatsRef.document(chatId)
                     .collection("members")
                     .document(createdBy)
+                */
 
-                myMemberRef.update("hidden", false).await()
+                inboxRef(createdBy, chatId).update("hidden", false).await()
                 return chatId
             }
         }
@@ -157,6 +182,14 @@ class ChatRepository(private val db: FirebaseFirestore) {
                     "lastReadAt" to null,
                     "hidden" to false
                 ))
+                    tx.set(inboxRef(uid, chatRef.id), mapOf(
+                        "chatId" to chatRef.id,
+                        "title" to title,
+                        "type" to "group",
+                        "lastMessageText" to null,
+                        "lastMessageAt" to null,
+                        "hidden" to false
+                    ))
             }
 
             tx.set(groupThreadRef, mapOf(
@@ -172,37 +205,23 @@ class ChatRepository(private val db: FirebaseFirestore) {
 
     /**
      * Get a list of chat summaries for the current user.
-     * Checks for Hidden attribute to decide wether to display chat
+     * Checks for Hidden attribute to decide whether to display chat
      */
     suspend fun getMyChats(myUid: String): List<ChatListItem> {
-        val snap = chatsRef
-            .whereArrayContains("memberIds", myUid)
+        val snap = usersRef.document(myUid)
+            .collection("inbox")
+            .whereEqualTo("hidden", false)
             .orderBy("lastMessageAt", Query.Direction.DESCENDING)
             .get()
             .await()
 
-        val result = mutableListOf<ChatListItem>()
-
-        for (doc in snap.documents) {
-            val memberSnap = doc.reference
-                .collection("members")
-                .document(myUid)
-                .get()
-                .await()
-
-            val hidden = memberSnap.getBoolean("hidden") ?: false
-            if (hidden) continue
-
-            result.add(
-                ChatListItem(
-                    id = doc.id,
-                    title = doc.getString("title") ?: "Untitled Chat",
-                    lastMessageText = doc.getString("lastMessageText")
-                )
+        return snap.documents.map { doc ->
+            ChatListItem(
+                id = doc.id,
+                title = doc.getString("title") ?: "Untitled Chat",
+                lastMessageText = doc.getString("lastMessageText")
             )
         }
-
-        return result
     }
 
     /**
@@ -223,6 +242,9 @@ class ChatRepository(private val db: FirebaseFirestore) {
         val chatRef = chatsRef.document(chatId)
         val messageRef = chatRef.collection("messages").document(messageId)
 
+        val chatSnap = chatRef.get().await()
+        val memberIds = (chatSnap.get("memberIds") as? List<*>)?.filterIsInstance<String>() ?: emptyList()
+
         val messageData = mapOf(
             "senderId" to senderId,
             "type" to "text",
@@ -238,11 +260,26 @@ class ChatRepository(private val db: FirebaseFirestore) {
             "lastMessageText" to text,
             "lastMessageSenderId" to senderId
         ))
+
+        memberIds.forEach { uid ->
+            batch.set(
+                inboxRef(uid, chatId),
+                mapOf(
+                    "chatId" to chatId,
+                    "title" to (chatSnap.getString("title") ?: "Chat"),
+                    "type" to (chatSnap.getString("type") ?: "dm"),
+                    "lastMessageText" to text,
+                    "lastMessageAt" to now
+                ),
+                com.google.firebase.firestore.SetOptions.merge()
+            )
+        }
+
         batch.commit().await()
     }
 
     /**
-     * Listen to recent messages in realtime.
+     * Listen to recent messages in realtime for chat logs.
      * Returns a ListenerRegistration; call remove() when the screen is disposed.
      */
     fun listenMessagesRealtime(
@@ -269,6 +306,41 @@ class ChatRepository(private val db: FirebaseFirestore) {
             val messages = docs.mapNotNull { docToMessage(it) }
             onSnapshot(messages, docs)
         }
+    }
+
+    /**
+     * This function specifically updates the most recent messages of each saved chat in the Friends Screen
+     */
+    fun listenToMyChats(
+        myUid: String,
+        onSnapshot: (List<ChatListItem>) -> Unit,
+        onError: ((Exception) -> Unit)? = null
+    ): ListenerRegistration {
+        return usersRef.document(myUid)
+            .collection("inbox")
+            .whereEqualTo("hidden", false)
+            .orderBy("lastMessageAt", Query.Direction.DESCENDING)
+            .addSnapshotListener { snap, err ->
+                if (err != null) {
+                    onError?.invoke(err)
+                    return@addSnapshotListener
+                }
+
+                if (snap == null) {
+                    onSnapshot(emptyList())
+                    return@addSnapshotListener
+                }
+
+                val chats = snap.documents.map { doc ->
+                    ChatListItem(
+                        id = doc.id,
+                        title = doc.getString("title") ?: "Untitled Chat",
+                        lastMessageText = doc.getString("lastMessageText")
+                    )
+                }
+
+                onSnapshot(chats)
+            }
     }
 
     /**
@@ -316,16 +388,22 @@ class ChatRepository(private val db: FirebaseFirestore) {
      * hides chats from users without deleting them from database
      */
     suspend fun hideChatForUser(chatId: String, myUid: String) {
+
+        /**
         val memberRef = chatsRef.document(chatId)
             .collection("members")
             .document(myUid)
+        */
 
-        memberRef.update("hidden", true).await()
+        inboxRef(myUid,chatId).update("hidden", true).await()
     }
 
     suspend fun getChatTitle(chatId: String): String {
         val doc = chatsRef.document(chatId).get().await()
         return doc.getString("title") ?: "Chat"
     }
+
+    private fun inboxRef(uid: String, chatId: String) =
+        usersRef.document(uid).collection("inbox").document(chatId)
 
 }

--- a/app/src/main/java/com/example/classseek/data/ChatRepository.kt
+++ b/app/src/main/java/com/example/classseek/data/ChatRepository.kt
@@ -2,8 +2,10 @@ package com.example.classseek.data
 
 import com.google.firebase.Timestamp
 import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FieldValue
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.firestore.MetadataChanges
 import com.google.firebase.firestore.Query
 import kotlinx.coroutines.tasks.await
 import java.util.UUID
@@ -14,7 +16,8 @@ data class Message(
     val type: String = "text",
     val text: String? = null,
     val createdAt: Timestamp? = null,
-    val replyToMessageId: String? = null
+    val replyToMessageId: String? = null,
+    val hasPendingWrites: Boolean = false
 )
 
 data class ChatListItem(
@@ -23,13 +26,17 @@ data class ChatListItem(
     val lastMessageText: String? = null
 )
 
+data class ReadReceiptState(
+    val otherUserId: String? = null,
+    val otherUserLastReadAt: Timestamp? = null,
+    val otherUserLastReadMessageId: String? = null
+)
+
 class ChatRepository(private val db: FirebaseFirestore) {
 
     private val chatsRef = db.collection("chats")
     private val dmThreadsRef = db.collection("dmThreads")
-
     private val groupThreadsRef = db.collection("groupThreads")
-
     private val usersRef = db.collection("users")
 
     /**
@@ -47,9 +54,8 @@ class ChatRepository(private val db: FirebaseFirestore) {
         val existing = dmDocRef.get().await()
         if (existing.exists()) {
             val chatId = existing.getString("chatId")
-
             if (!chatId.isNullOrBlank()) {
-                inboxRef(uidA,chatId).update("hidden", false).await()
+                inboxRef(uidA, chatId).update("hidden", false).await()
                 return chatId
             }
         }
@@ -58,59 +64,87 @@ class ChatRepository(private val db: FirebaseFirestore) {
 
         db.runTransaction { tx ->
             val now = Timestamp.now()
-
             val finalTitle = if (title.isNullOrBlank()) "Chat" else title.trim()
 
-            tx.set(newChatRef, mapOf(
-                "type" to "dm",
-                "title" to finalTitle,
-                "memberIds" to listOf(a, b),
-                "createdAt" to now,
-                "createdBy" to uidA,
-                "memberCount" to 2,
-                "lastMessageAt" to null,
-                "lastMessageText" to null,
-                "lastMessageSenderId" to null,
-                "hidden" to false
-            ))
+            tx.set(
+                newChatRef,
+                mapOf(
+                    "type" to "dm",
+                    "title" to finalTitle,
+                    "memberIds" to listOf(a, b),
+                    "createdAt" to now,
+                    "createdBy" to uidA,
+                    "memberCount" to 2,
+                    "lastMessageAt" to null,
+                    "lastMessageText" to null,
+                    "lastMessageSenderId" to null,
+                    "hidden" to false
+                )
+            )
 
             val memberARef = newChatRef.collection("members").document(a)
             val memberBRef = newChatRef.collection("members").document(b)
 
-            tx.set(memberARef, mapOf("role" to "member", "joinedAt" to now, "lastReadAt" to null))
-            tx.set(memberBRef, mapOf("role" to "member", "joinedAt" to now, "lastReadAt" to null))
+            tx.set(
+                memberARef,
+                mapOf(
+                    "role" to "member",
+                    "joinedAt" to now,
+                    "lastReadAt" to null,
+                    "lastReadMessageId" to null
+                )
+            )
 
-            tx.set(inboxRef(a, newChatRef.id), mapOf(
-                "chatId" to newChatRef.id,
-                "title" to finalTitle,
-                "type" to "dm",
-                "lastMessageText" to null,
-                "lastMessageAt" to null,
-                "hidden" to false
-            ))
+            tx.set(
+                memberBRef,
+                mapOf(
+                    "role" to "member",
+                    "joinedAt" to now,
+                    "lastReadAt" to null,
+                    "lastReadMessageId" to null
+                )
+            )
 
-            tx.set(inboxRef(b, newChatRef.id), mapOf(
-                "chatId" to newChatRef.id,
-                "title" to finalTitle,
-                "type" to "dm",
-                "lastMessageText" to null,
-                "lastMessageAt" to null,
-                "hidden" to false
-            ))
+            tx.set(
+                inboxRef(a, newChatRef.id),
+                mapOf(
+                    "chatId" to newChatRef.id,
+                    "title" to finalTitle,
+                    "type" to "dm",
+                    "lastMessageText" to null,
+                    "lastMessageAt" to null,
+                    "hidden" to false
+                )
+            )
 
-            tx.set(dmDocRef, mapOf(
-                "chatId" to newChatRef.id,
-                "userA" to a,
-                "userB" to b,
-                "createdAt" to now
-            ))
+            tx.set(
+                inboxRef(b, newChatRef.id),
+                mapOf(
+                    "chatId" to newChatRef.id,
+                    "title" to finalTitle,
+                    "type" to "dm",
+                    "lastMessageText" to null,
+                    "lastMessageAt" to null,
+                    "hidden" to false
+                )
+            )
+
+            tx.set(
+                dmDocRef,
+                mapOf(
+                    "chatId" to newChatRef.id,
+                    "userA" to a,
+                    "userB" to b,
+                    "createdAt" to now
+                )
+            )
         }.await()
 
         return newChatRef.id
     }
 
     /**
-    Possibly temporary until real user accounts are created.
+     * Possibly temporary until real user accounts are created.
      */
     private fun buildGroupKey(memberIds: List<String>): String {
         return memberIds
@@ -147,44 +181,59 @@ class ChatRepository(private val db: FirebaseFirestore) {
         db.runTransaction { tx ->
             val now = Timestamp.now()
 
-            tx.set(chatRef, mapOf(
-                "type" to "group",
-                "title" to title,
-                "memberIds" to uniqueMembers,
-                "createdAt" to now,
-                "createdBy" to createdBy,
-                "memberCount" to uniqueMembers.size,
-                "photoURL" to (photoURL ?: ""),
-                "lastMessageAt" to null,
-                "lastMessageText" to null,
-                "lastMessageSenderId" to null
-            ))
+            tx.set(
+                chatRef,
+                mapOf(
+                    "type" to "group",
+                    "title" to title,
+                    "memberIds" to uniqueMembers,
+                    "createdAt" to now,
+                    "createdBy" to createdBy,
+                    "memberCount" to uniqueMembers.size,
+                    "photoURL" to (photoURL ?: ""),
+                    "lastMessageAt" to null,
+                    "lastMessageText" to null,
+                    "lastMessageSenderId" to null
+                )
+            )
 
             uniqueMembers.forEach { uid ->
                 val role = if (uid == createdBy) "owner" else "member"
                 val memberRef = chatRef.collection("members").document(uid)
-                tx.set(memberRef, mapOf(
-                    "role" to role,
-                    "joinedAt" to now,
-                    "lastReadAt" to null,
-                    "hidden" to false
-                ))
-                    tx.set(inboxRef(uid, chatRef.id), mapOf(
+
+                tx.set(
+                    memberRef,
+                    mapOf(
+                        "role" to role,
+                        "joinedAt" to now,
+                        "lastReadAt" to null,
+                        "lastReadMessageId" to null,
+                        "hidden" to false
+                    )
+                )
+
+                tx.set(
+                    inboxRef(uid, chatRef.id),
+                    mapOf(
                         "chatId" to chatRef.id,
                         "title" to title,
                         "type" to "group",
                         "lastMessageText" to null,
                         "lastMessageAt" to null,
                         "hidden" to false
-                    ))
+                    )
+                )
             }
 
-            tx.set(groupThreadRef, mapOf(
-                "chatId" to chatRef.id,
-                "groupKey" to groupKey,
-                "memberIds" to uniqueMembers,
-                "createdAt" to now
-            ))
+            tx.set(
+                groupThreadRef,
+                mapOf(
+                    "chatId" to chatRef.id,
+                    "groupKey" to groupKey,
+                    "memberIds" to uniqueMembers,
+                    "createdAt" to now
+                )
+            )
         }.await()
 
         return chatRef.id
@@ -192,7 +241,7 @@ class ChatRepository(private val db: FirebaseFirestore) {
 
     /**
      * Get a list of chat summaries for the current user.
-     * Checks for Hidden attribute to decide whether to display chat
+     * Checks hidden attribute to decide whether to display chat.
      */
     suspend fun getMyChats(myUid: String): List<ChatListItem> {
         val snap = usersRef.document(myUid)
@@ -223,30 +272,34 @@ class ChatRepository(private val db: FirebaseFirestore) {
         text: String,
         replyToMessageId: String? = null
     ) {
-        val now = Timestamp.now()
         val messageId = UUID.randomUUID().toString()
 
         val chatRef = chatsRef.document(chatId)
         val messageRef = chatRef.collection("messages").document(messageId)
 
         val chatSnap = chatRef.get().await()
-        val memberIds = (chatSnap.get("memberIds") as? List<*>)?.filterIsInstance<String>() ?: emptyList()
+        val memberIds =
+            (chatSnap.get("memberIds") as? List<*>)?.filterIsInstance<String>() ?: emptyList()
 
         val messageData = mapOf(
             "senderId" to senderId,
             "type" to "text",
             "text" to text,
-            "createdAt" to now,
+            "createdAt" to FieldValue.serverTimestamp(),
             "replyToMessageId" to replyToMessageId
         )
 
         val batch = db.batch()
         batch.set(messageRef, messageData)
-        batch.update(chatRef, mapOf(
-            "lastMessageAt" to now,
-            "lastMessageText" to text,
-            "lastMessageSenderId" to senderId
-        ))
+
+        batch.update(
+            chatRef,
+            mapOf(
+                "lastMessageAt" to FieldValue.serverTimestamp(),
+                "lastMessageText" to text,
+                "lastMessageSenderId" to senderId
+            )
+        )
 
         memberIds.forEach { uid ->
             batch.set(
@@ -256,7 +309,7 @@ class ChatRepository(private val db: FirebaseFirestore) {
                     "title" to (chatSnap.getString("title") ?: "Chat"),
                     "type" to (chatSnap.getString("type") ?: "dm"),
                     "lastMessageText" to text,
-                    "lastMessageAt" to now
+                    "lastMessageAt" to FieldValue.serverTimestamp()
                 ),
                 com.google.firebase.firestore.SetOptions.merge()
             )
@@ -280,15 +333,17 @@ class ChatRepository(private val db: FirebaseFirestore) {
             .orderBy("createdAt", Query.Direction.DESCENDING)
             .limit(pageSize.toLong())
 
-        return q.addSnapshotListener { snap, err ->
+        return q.addSnapshotListener(MetadataChanges.INCLUDE) { snap, err ->
             if (err != null) {
                 onError?.invoke(err)
                 return@addSnapshotListener
             }
+
             if (snap == null) {
                 onSnapshot(emptyList(), emptyList())
                 return@addSnapshotListener
             }
+
             val docs = snap.documents
             val messages = docs.mapNotNull { docToMessage(it) }
             onSnapshot(messages, docs)
@@ -296,7 +351,7 @@ class ChatRepository(private val db: FirebaseFirestore) {
     }
 
     /**
-     * This function specifically updates the most recent messages of each saved chat in the Friends Screen
+     * This function specifically updates the most recent messages of each saved chat in the Friends screen.
      */
     fun listenToMyChats(
         myUid: String,
@@ -330,6 +385,25 @@ class ChatRepository(private val db: FirebaseFirestore) {
             }
     }
 
+    fun listenToMyReadState(
+        chatId: String,
+        myUid: String,
+        onSnapshot: (String?) -> Unit,
+        onError: ((Exception) -> Unit)? = null
+    ): ListenerRegistration {
+        return chatsRef.document(chatId)
+            .collection("members")
+            .document(myUid)
+            .addSnapshotListener { snap, err ->
+                if (err != null) {
+                    onError?.invoke(err)
+                    return@addSnapshotListener
+                }
+
+                onSnapshot(snap?.getString("lastReadMessageId"))
+            }
+    }
+
     /**
      * Pagination: load older messages after the last seen DocumentSnapshot.
      */
@@ -351,31 +425,43 @@ class ChatRepository(private val db: FirebaseFirestore) {
     }
 
     /**
-     * Update the user's lastReadAt field in the membership doc.
-     * Call when user opens the chat or after they scroll to bottom.
+     * Update the user's read state in the membership doc.
+     * Call when user opens the chat or after a newly visible incoming message is shown.
      */
-    suspend fun updateMyLastRead(chatId: String, myUid: String) {
+    suspend fun updateMyLastRead(
+        chatId: String,
+        myUid: String,
+        lastReadMessageId: String?
+    ) {
         val memberRef = chatsRef.document(chatId).collection("members").document(myUid)
-        memberRef.update("lastReadAt", Timestamp.now()).await()
+
+        memberRef.update(
+            mapOf(
+                "lastReadAt" to FieldValue.serverTimestamp(),
+                "lastReadMessageId" to lastReadMessageId
+            )
+        ).await()
     }
 
     private fun docToMessage(doc: DocumentSnapshot): Message? {
         val senderId = doc.getString("senderId") ?: return null
+
         return Message(
             id = doc.id,
             senderId = senderId,
             type = doc.getString("type") ?: "text",
             text = doc.getString("text"),
             createdAt = doc.getTimestamp("createdAt"),
-            replyToMessageId = doc.getString("replyToMessageId")
+            replyToMessageId = doc.getString("replyToMessageId"),
+            hasPendingWrites = doc.metadata.hasPendingWrites()
         )
     }
 
     /**
-     * hides chats from users without deleting them from database
+     * Hides chats from users without deleting them from database.
      */
     suspend fun hideChatForUser(chatId: String, myUid: String) {
-        inboxRef(myUid,chatId).update("hidden", true).await()
+        inboxRef(myUid, chatId).update("hidden", true).await()
     }
 
     suspend fun getChatTitle(chatId: String): String {
@@ -383,7 +469,37 @@ class ChatRepository(private val db: FirebaseFirestore) {
         return doc.getString("title") ?: "Chat"
     }
 
+    fun listenToDmReadReceipt(
+        chatId: String,
+        myUid: String,
+        onSnapshot: (ReadReceiptState) -> Unit,
+        onError: ((Exception) -> Unit)? = null
+    ): ListenerRegistration {
+        val membersRef = chatsRef.document(chatId).collection("members")
+
+        return membersRef.addSnapshotListener { snap, err ->
+            if (err != null) {
+                onError?.invoke(err)
+                return@addSnapshotListener
+            }
+
+            if (snap == null) {
+                onSnapshot(ReadReceiptState())
+                return@addSnapshotListener
+            }
+
+            val otherDoc = snap.documents.firstOrNull { it.id != myUid }
+
+            onSnapshot(
+                ReadReceiptState(
+                    otherUserId = otherDoc?.id,
+                    otherUserLastReadAt = otherDoc?.getTimestamp("lastReadAt"),
+                    otherUserLastReadMessageId = otherDoc?.getString("lastReadMessageId")
+                )
+            )
+        }
+    }
+
     private fun inboxRef(uid: String, chatId: String) =
         usersRef.document(uid).collection("inbox").document(chatId)
-
 }

--- a/app/src/main/java/com/example/classseek/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/chat/ChatScreen.kt
@@ -36,20 +36,27 @@ fun ChatScreen(
     val messages = remember(chatId) { mutableStateListOf<Message>() }
     val listState = rememberLazyListState()
 
-    var input by remember { mutableStateOf("") }
-    var error by remember { mutableStateOf<String?>(null) }
-    var sending by remember { mutableStateOf(false) }
+    var input by remember(chatId) { mutableStateOf("") }
+    var error by remember(chatId) { mutableStateOf<String?>(null) }
+    var sending by remember(chatId) { mutableStateOf(false) }
 
     var initialReadMarked by remember(chatId) { mutableStateOf(false) }
     var initialScrollDone by remember(chatId) { mutableStateOf(false) }
-    var isChatVisible by remember { mutableStateOf(false) }
+    var isChatVisible by remember(chatId) { mutableStateOf(false) }
     var lastMarkedIncomingMessageId by remember(chatId) { mutableStateOf<String?>(null) }
 
     var myLastReadMessageId by remember(chatId) { mutableStateOf<String?>(null) }
     var otherUserLastReadMessageId by remember(chatId) { mutableStateOf<String?>(null) }
 
-    var pendingScrollToOwnMessage by remember(chatId) { mutableStateOf(false) }
-    var lastAutoScrolledToMyMessageId by remember(chatId) { mutableStateOf<String?>(null) }
+    var pendingScrollToMessageId by remember(chatId) { mutableStateOf<String?>(null) }
+    var lastAutoScrolledToMessageId by remember(chatId) { mutableStateOf<String?>(null) }
+
+    // Helps avoid initial-position scroll before my read-state listener has had a chance to respond.
+    var myReadStateLoaded by remember(chatId) { mutableStateOf(false) }
+
+    // Once the user has sent a message in this screen instance,
+    // never allow the initial "scroll to last read" logic to run again.
+    var hasSentMessageThisSession by remember(chatId) { mutableStateOf(false) }
 
     val newestVisible = messages.firstOrNull()
     val myLatestMessage = messages.firstOrNull { it.senderId == myUid }
@@ -66,7 +73,7 @@ fun ChatScreen(
                 otherUserLastReadMessageId == latest.id
     }
 
-    DisposableEffect(lifecycleOwner) {
+    DisposableEffect(lifecycleOwner, chatId) {
         val observer = LifecycleEventObserver { _, event ->
             isChatVisible = event == Lifecycle.Event.ON_RESUME
         }
@@ -77,6 +84,9 @@ fun ChatScreen(
         }
     }
 
+    /**
+     * Initial mark-read.
+     */
     LaunchedEffect(chatId, myUid, messages.size) {
         val uid = myUid ?: return@LaunchedEffect
         val newest = newestVisible ?: return@LaunchedEffect
@@ -91,6 +101,9 @@ fun ChatScreen(
         }
     }
 
+    /**
+     * While visible, mark newly arrived incoming messages as read.
+     */
     LaunchedEffect(chatId, myUid, isChatVisible, newestVisible?.id) {
         val uid = myUid ?: return@LaunchedEffect
         val newest = newestVisible ?: return@LaunchedEffect
@@ -108,8 +121,27 @@ fun ChatScreen(
         }
     }
 
-    LaunchedEffect(messages.size, myLastReadMessageId, chatId) {
-        if (initialScrollDone || messages.isEmpty()) return@LaunchedEffect
+    /**
+     * Initial snap to last-read position.
+     *
+     * IMPORTANT:
+     * - Do not run if a send-scroll is pending.
+     * - Do not run if the user has already sent a message in this session.
+     * - Only run once.
+     */
+    LaunchedEffect(
+        messages.size,
+        myLastReadMessageId,
+        myReadStateLoaded,
+        pendingScrollToMessageId,
+        hasSentMessageThisSession,
+        chatId
+    ) {
+        if (initialScrollDone) return@LaunchedEffect
+        if (messages.isEmpty()) return@LaunchedEffect
+        if (!myReadStateLoaded) return@LaunchedEffect
+        if (pendingScrollToMessageId != null) return@LaunchedEffect
+        if (hasSentMessageThisSession) return@LaunchedEffect
 
         val targetIndex = when {
             myLastReadMessageId != null -> {
@@ -124,25 +156,35 @@ fun ChatScreen(
         }
 
         awaitFrame()
+        awaitFrame()
         listState.scrollToItem(targetIndex)
         initialScrollDone = true
     }
 
-    LaunchedEffect(latestMyMessageId, messages.size, pendingScrollToOwnMessage, sending) {
-        if (!pendingScrollToOwnMessage) return@LaunchedEffect
+    /**
+     * Sent-message snap.
+     *
+     * This has priority over everything else.
+     */
+    LaunchedEffect(messages.size, pendingScrollToMessageId, chatId) {
+        val targetMessageId = pendingScrollToMessageId ?: return@LaunchedEffect
         if (messages.isEmpty()) return@LaunchedEffect
+        if (targetMessageId == lastAutoScrolledToMessageId) return@LaunchedEffect
 
-        val latest = myLatestMessage ?: return@LaunchedEffect
-        if (latest.id == lastAutoScrolledToMyMessageId) return@LaunchedEffect
-
-        awaitFrame()
-        listState.scrollToItem(0)
+        val targetIndex = messages.indexOfFirst { it.id == targetMessageId }
+        if (targetIndex < 0) return@LaunchedEffect
 
         awaitFrame()
-        listState.scrollToItem(0)
+        awaitFrame()
+        listState.scrollToItem(targetIndex)
 
-        lastAutoScrolledToMyMessageId = latest.id
-        pendingScrollToOwnMessage = false
+        // Extra pass for IME/layout changes
+        awaitFrame()
+        listState.scrollToItem(targetIndex)
+
+        lastAutoScrolledToMessageId = targetMessageId
+        pendingScrollToMessageId = null
+        initialScrollDone = true
     }
 
     DisposableEffect(chatId) {
@@ -150,15 +192,8 @@ fun ChatScreen(
             chatId = chatId,
             pageSize = 50,
             onSnapshot = { newMessages, _ ->
-                val sortedMessages = newMessages.sortedWith(
-                    compareByDescending<Message> { it.hasPendingWrites }
-                        .thenByDescending { it.createdAt?.seconds ?: Long.MIN_VALUE }
-                        .thenByDescending { it.createdAt?.nanoseconds ?: Int.MIN_VALUE }
-                        .thenByDescending { it.id }
-                )
-
                 messages.clear()
-                messages.addAll(sortedMessages)
+                messages.addAll(newMessages)
                 error = null
             },
             onError = { e ->
@@ -197,9 +232,11 @@ fun ChatScreen(
                 myUid = myUid,
                 onSnapshot = { lastReadId ->
                     myLastReadMessageId = lastReadId
+                    myReadStateLoaded = true
                 },
                 onError = { e ->
                     error = e.message ?: "My read state listener error"
+                    myReadStateLoaded = true
                 }
             )
 
@@ -238,9 +275,12 @@ fun ChatScreen(
                     .fillMaxWidth()
                     .padding(horizontal = 12.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
-                contentPadding = PaddingValues(top = 16.dp, bottom = 16.dp)
+                contentPadding = PaddingValues(top = 16.dp, bottom = 72.dp)
             ) {
-                items(messages, key = { it.id }) { msg ->
+                items(
+                    items = messages,
+                    key = { it.id }
+                ) { msg ->
                     MessageRow(
                         msg = msg,
                         isMine = (myUid != null && msg.senderId == myUid),
@@ -286,19 +326,32 @@ fun ChatScreen(
                         val text = input.trim()
 
                         sending = true
-                        pendingScrollToOwnMessage = true
+                        hasSentMessageThisSession = true
+                        initialScrollDone = true
 
                         scope.launch {
                             try {
-                                repo.sendTextMessage(
+                                val sentMessageId = repo.sendTextMessage(
                                     chatId = chatId,
                                     senderId = uid,
                                     text = text
                                 )
+
+                                // Scroll to the exact message that was sent.
+                                pendingScrollToMessageId = sentMessageId
+
+                                // Keep my own read state aligned with my newest sent message too.
+                                // This prevents late read-state updates from pointing to an older anchor.
+                                try {
+                                    repo.updateMyLastRead(chatId, uid, sentMessageId)
+                                    myLastReadMessageId = sentMessageId
+                                } catch (_: Exception) {
+                                }
+
                                 input = ""
                             } catch (e: Exception) {
                                 error = e.message ?: "Send failed"
-                                pendingScrollToOwnMessage = false
+                                pendingScrollToMessageId = null
                             } finally {
                                 sending = false
                             }

--- a/app/src/main/java/com/example/classseek/ui/chat/ChatScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/chat/ChatScreen.kt
@@ -3,15 +3,20 @@ package com.example.classseek.ui.chat
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.example.classseek.data.ChatRepository
 import com.example.classseek.data.Message
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.firestore.FirebaseFirestore
+import kotlinx.coroutines.android.awaitFrame
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -25,45 +30,199 @@ fun ChatScreen(
     auth: FirebaseAuth = remember { FirebaseAuth.getInstance() }
 ) {
     val scope = rememberCoroutineScope()
+    val lifecycleOwner = LocalLifecycleOwner.current
     val myUid = auth.currentUser?.uid
 
-    val messages = remember { mutableStateListOf<Message>() }
+    val messages = remember(chatId) { mutableStateListOf<Message>() }
+    val listState = rememberLazyListState()
+
     var input by remember { mutableStateOf("") }
     var error by remember { mutableStateOf<String?>(null) }
     var sending by remember { mutableStateOf(false) }
 
-    // Start realtime listener
+    var initialReadMarked by remember(chatId) { mutableStateOf(false) }
+    var initialScrollDone by remember(chatId) { mutableStateOf(false) }
+    var isChatVisible by remember { mutableStateOf(false) }
+    var lastMarkedIncomingMessageId by remember(chatId) { mutableStateOf<String?>(null) }
+
+    var myLastReadMessageId by remember(chatId) { mutableStateOf<String?>(null) }
+    var otherUserLastReadMessageId by remember(chatId) { mutableStateOf<String?>(null) }
+
+    var pendingScrollToOwnMessage by remember(chatId) { mutableStateOf(false) }
+    var lastAutoScrolledToMyMessageId by remember(chatId) { mutableStateOf<String?>(null) }
+
+    val newestVisible = messages.firstOrNull()
+    val myLatestMessage = messages.firstOrNull { it.senderId == myUid }
+    val latestMyMessageId = myLatestMessage?.id
+
+    val latestSeen = remember(
+        myLatestMessage?.id,
+        myLatestMessage?.hasPendingWrites,
+        otherUserLastReadMessageId
+    ) {
+        val latest = myLatestMessage
+        latest != null &&
+                !latest.hasPendingWrites &&
+                otherUserLastReadMessageId == latest.id
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            isChatVisible = event == Lifecycle.Event.ON_RESUME
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    LaunchedEffect(chatId, myUid, messages.size) {
+        val uid = myUid ?: return@LaunchedEffect
+        val newest = newestVisible ?: return@LaunchedEffect
+
+        if (!initialReadMarked) {
+            try {
+                repo.updateMyLastRead(chatId, uid, newest.id)
+                lastMarkedIncomingMessageId = if (newest.senderId != uid) newest.id else null
+                initialReadMarked = true
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    LaunchedEffect(chatId, myUid, isChatVisible, newestVisible?.id) {
+        val uid = myUid ?: return@LaunchedEffect
+        val newest = newestVisible ?: return@LaunchedEffect
+
+        if (
+            isChatVisible &&
+            newest.senderId != uid &&
+            newest.id != lastMarkedIncomingMessageId
+        ) {
+            try {
+                repo.updateMyLastRead(chatId, uid, newest.id)
+                lastMarkedIncomingMessageId = newest.id
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    LaunchedEffect(messages.size, myLastReadMessageId, chatId) {
+        if (initialScrollDone || messages.isEmpty()) return@LaunchedEffect
+
+        val targetIndex = when {
+            myLastReadMessageId != null -> {
+                val idx = messages.indexOfFirst { it.id == myLastReadMessageId }
+                if (idx >= 0) {
+                    (idx - 1).coerceAtLeast(0)
+                } else {
+                    0
+                }
+            }
+            else -> 0
+        }
+
+        awaitFrame()
+        listState.scrollToItem(targetIndex)
+        initialScrollDone = true
+    }
+
+    LaunchedEffect(latestMyMessageId, messages.size, pendingScrollToOwnMessage, sending) {
+        if (!pendingScrollToOwnMessage) return@LaunchedEffect
+        if (messages.isEmpty()) return@LaunchedEffect
+
+        val latest = myLatestMessage ?: return@LaunchedEffect
+        if (latest.id == lastAutoScrolledToMyMessageId) return@LaunchedEffect
+
+        awaitFrame()
+        listState.scrollToItem(0)
+
+        awaitFrame()
+        listState.scrollToItem(0)
+
+        lastAutoScrolledToMyMessageId = latest.id
+        pendingScrollToOwnMessage = false
+    }
+
     DisposableEffect(chatId) {
-        val reg = repo.listenMessagesRealtime(
+        val messagesReg = repo.listenMessagesRealtime(
             chatId = chatId,
             pageSize = 50,
             onSnapshot = { newMessages, _ ->
-                // repo returns newest-first; show oldest-first
+                val sortedMessages = newMessages.sortedWith(
+                    compareByDescending<Message> { it.hasPendingWrites }
+                        .thenByDescending { it.createdAt?.seconds ?: Long.MIN_VALUE }
+                        .thenByDescending { it.createdAt?.nanoseconds ?: Int.MIN_VALUE }
+                        .thenByDescending { it.id }
+                )
+
                 messages.clear()
-                messages.addAll(newMessages.asReversed())
+                messages.addAll(sortedMessages)
                 error = null
             },
-            onError = { e -> error = e.message ?: "Listener error" }
+            onError = { e ->
+                error = e.message ?: "Listener error"
+            }
         )
-        onDispose { reg.remove() }
+
+        onDispose { messagesReg.remove() }
+    }
+
+    DisposableEffect(chatId, myUid) {
+        if (myUid == null) {
+            onDispose { }
+        } else {
+            val receiptReg = repo.listenToDmReadReceipt(
+                chatId = chatId,
+                myUid = myUid,
+                onSnapshot = { state ->
+                    otherUserLastReadMessageId = state.otherUserLastReadMessageId
+                },
+                onError = { e ->
+                    error = e.message ?: "Read receipt listener error"
+                }
+            )
+
+            onDispose { receiptReg.remove() }
+        }
+    }
+
+    DisposableEffect(chatId, myUid) {
+        if (myUid == null) {
+            onDispose { }
+        } else {
+            val myReadReg = repo.listenToMyReadState(
+                chatId = chatId,
+                myUid = myUid,
+                onSnapshot = { lastReadId ->
+                    myLastReadMessageId = lastReadId
+                },
+                onError = { e ->
+                    error = e.message ?: "My read state listener error"
+                }
+            )
+
+            onDispose { myReadReg.remove() }
+        }
     }
 
     Scaffold(
-        modifier = modifier.fillMaxSize(),
-        topBar = {
+        modifier = modifier.fillMaxSize()
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize()
+                .imePadding()
+        ) {
             TopAppBar(
                 title = { Text(title) },
                 navigationIcon = {
                     TextButton(onClick = onBack) { Text("Back") }
                 }
             )
-        }
-    ) { innerPadding ->
-        Column(
-            modifier = Modifier
-                .padding(innerPadding)
-                .fillMaxSize()
-        ) {
+
             if (error != null) {
                 Text(
                     text = "Error: $error",
@@ -72,26 +231,39 @@ fun ChatScreen(
             }
 
             LazyColumn(
+                state = listState,
+                reverseLayout = true,
                 modifier = Modifier
                     .weight(1f)
                     .fillMaxWidth()
                     .padding(horizontal = 12.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                contentPadding = PaddingValues(top = 16.dp, bottom = 16.dp)
             ) {
                 items(messages, key = { it.id }) { msg ->
                     MessageRow(
                         msg = msg,
-                        isMine = (myUid != null && msg.senderId == myUid)
+                        isMine = (myUid != null && msg.senderId == myUid),
+                        showReceipt = msg.id == latestMyMessageId,
+                        receiptText = if (msg.id == latestMyMessageId) {
+                            when {
+                                msg.hasPendingWrites -> "Sending..."
+                                latestSeen -> "Seen"
+                                else -> "Sent"
+                            }
+                        } else {
+                            null
+                        }
                     )
                 }
             }
 
-            Divider()
+            HorizontalDivider()
 
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(12.dp),
+                    .padding(horizontal = 8.dp, vertical = 6.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 OutlinedTextField(
@@ -99,8 +271,10 @@ fun ChatScreen(
                     value = input,
                     onValueChange = { input = it },
                     label = { Text("Message") },
-                    singleLine = true,
-                    enabled = myUid != null && !sending
+                    singleLine = false,
+                    enabled = myUid != null && !sending,
+                    minLines = 1,
+                    maxLines = 20
                 )
 
                 Spacer(Modifier.width(8.dp))
@@ -110,13 +284,21 @@ fun ChatScreen(
                     onClick = {
                         val uid = myUid ?: return@Button
                         val text = input.trim()
+
                         sending = true
+                        pendingScrollToOwnMessage = true
+
                         scope.launch {
                             try {
-                                repo.sendTextMessage(chatId = chatId, senderId = uid, text = text)
+                                repo.sendTextMessage(
+                                    chatId = chatId,
+                                    senderId = uid,
+                                    text = text
+                                )
                                 input = ""
                             } catch (e: Exception) {
                                 error = e.message ?: "Send failed"
+                                pendingScrollToOwnMessage = false
                             } finally {
                                 sending = false
                             }
@@ -131,7 +313,12 @@ fun ChatScreen(
 }
 
 @Composable
-private fun MessageRow(msg: Message, isMine: Boolean) {
+private fun MessageRow(
+    msg: Message,
+    isMine: Boolean,
+    showReceipt: Boolean = false,
+    receiptText: String? = null
+) {
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = if (isMine) Alignment.End else Alignment.Start
@@ -144,10 +331,19 @@ private fun MessageRow(msg: Message, isMine: Boolean) {
                 Text(msg.text ?: "[${msg.type}]")
             }
         }
+
         Spacer(Modifier.height(2.dp))
+
         Text(
             text = if (isMine) "You" else msg.senderId,
             style = MaterialTheme.typography.labelSmall
         )
+
+        if (isMine && showReceipt && receiptText != null) {
+            Text(
+                text = receiptText,
+                style = MaterialTheme.typography.labelSmall
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/classseek/ui/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/friends/FriendsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.classseek.data.ChatListItem
@@ -99,6 +100,28 @@ fun FriendsScreen(
             }
         )
         return
+    }
+
+    DisposableEffect(myUid) {
+        val uid = myUid
+        if (uid == null) {
+            onDispose { }
+        } else {
+            val registration = repo.listenToMyChats(
+                myUid = uid,
+                onSnapshot = { chats ->
+                    myChats.clear()
+                    myChats.addAll(chats)
+                },
+                onError = { e ->
+                    status = e.message ?: "Failed to listen to chats"
+                }
+            )
+
+            onDispose {
+                registration.remove()
+            }
+        }
     }
 
     LazyColumn(

--- a/app/src/main/java/com/example/classseek/ui/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/friends/FriendsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.DropdownMenu
@@ -62,6 +63,12 @@ fun FriendsScreen(
 
     val myChats = remember { mutableStateListOf<ChatListItem>() }
 
+    /**
+    Temporary vars for temp group chat UI to test groupchat implementation
+     */
+    var groupTitle by remember { mutableStateOf("") }
+    var groupMembersInput by remember { mutableStateOf("") }
+
     suspend fun refreshChats() {
         val uid = auth.currentUser?.uid ?: return
         val chats = repo.getMyChats(uid)
@@ -94,95 +101,194 @@ fun FriendsScreen(
         return
     }
 
-    Column(
+    LazyColumn(
         modifier = modifier
             .fillMaxSize()
-            .padding(16.dp)
+            .padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        Text("=== DEBUG INFO ===")
-        Text("Signed in: $isSignedIn")
-        Text("My UID: ${myUid ?: "NULL"}")
+        item {
+            Text("=== DEBUG INFO ===")
+            Text("Signed in: $isSignedIn")
+            Text("My UID: ${myUid ?: "NULL"}")
 
-        Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(16.dp))
 
-        Text(
-            text = "Create DM",
-            style = MaterialTheme.typography.headlineSmall
-        )
+            Text(
+                text = "Create DM",
+                style = MaterialTheme.typography.headlineSmall
+            )
+        }
+        item {
+            Spacer(Modifier.height(12.dp))
 
-        Spacer(Modifier.height(12.dp))
+            OutlinedTextField(
+                value = otherUid,
+                onValueChange = { otherUid = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Enter friend's UID") },
+                singleLine = true,
+                enabled = !working
+            )
+        }
 
-        OutlinedTextField(
-            value = otherUid,
-            onValueChange = { otherUid = it },
-            modifier = Modifier.fillMaxWidth(),
-            label = { Text("Enter friend's UID") },
-            singleLine = true,
-            enabled = !working
-        )
+        item {
+            Spacer(Modifier.height(8.dp))
 
-        Spacer(Modifier.height(8.dp))
+            OutlinedTextField(
+                value = chatTitle,
+                onValueChange = { chatTitle = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Chat name (optional)") },
+                singleLine = true,
+                enabled = !working
+            )
+        }
 
-        OutlinedTextField(
-            value = chatTitle,
-            onValueChange = { chatTitle = it },
-            modifier = Modifier.fillMaxWidth(),
-            label = { Text("Chat name (optional)") },
-            singleLine = true,
-            enabled = !working
-        )
+        item {
+            Spacer(Modifier.height(12.dp))
 
-        Spacer(Modifier.height(12.dp))
+            Button(
+                enabled = otherUid.trim().isNotEmpty() && !working && isSignedIn,
+                onClick = {
+                    scope.launch {
+                        try {
+                            working = true
+                            status = null
 
-        Button(
-            enabled = otherUid.trim().isNotEmpty() && !working && isSignedIn,
-            onClick = {
-                scope.launch {
-                    try {
-                        working = true
-                        status = null
+                            val uid = auth.currentUser?.uid
+                                ?: throw Exception("User not signed in")
 
-                        val uid = auth.currentUser?.uid
-                            ?: throw Exception("User not signed in")
+                            val targetUid = otherUid.trim()
+                            val defaultTitle = "Chat ${myChats.size + 1}"
+                            val firstTitle = if (chatTitle.trim().isBlank()) {
+                                defaultTitle
+                            } else {
+                                chatTitle.trim()
+                            }
 
-                        val targetUid = otherUid.trim()
-                        val defaultTitle = "Chat ${myChats.size + 1}"
-                        val firstTitle = if (chatTitle.trim().isBlank()) {
-                            defaultTitle
-                        } else {
-                            chatTitle.trim()
+                            val createdChatId = repo.openOrCreateDm(
+                                uidA = uid,
+                                uidB = targetUid,
+                                title = firstTitle
+                            )
+
+                            val finalTitle = repo.getChatTitle(createdChatId)
+
+                            refreshChats()
+                            selectedChatId = createdChatId
+                            selectedChatTitle = finalTitle
+                            chatTitle = ""
+                            otherUid = ""
+
+                        } catch (e: Exception) {
+                            status = e.message ?: "Failed to create DM"
+                        } finally {
+                            working = false
                         }
-
-                        val createdChatId = repo.openOrCreateDm(
-                            uidA = uid,
-                            uidB = targetUid,
-                            title = firstTitle
-                        )
-
-                        val finalTitle = repo.getChatTitle(createdChatId)
-
-                        refreshChats()
-                        selectedChatId = createdChatId
-                        selectedChatTitle = finalTitle
-                        chatTitle = ""
-                        otherUid = ""
-
-                    } catch (e: Exception) {
-                        status = e.message ?: "Failed to create DM"
-                    } finally {
-                        working = false
                     }
                 }
+            ) {
+                Text(if (working) "Working…" else "Create DM")
             }
-        ) {
-            Text(if (working) "Working…" else "Create DM")
+
+            if (status != null) {
+                Spacer(Modifier.height(12.dp))
+                Text("Status: $status")
+            }
         }
 
-        if (status != null) {
+        /**
+        temporary implementation of groupchat UI
+         */
+        item {
+            Spacer(Modifier.height(24.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(16.dp))
+
+            Text(
+                text = "Create Group Chat",
+                style = MaterialTheme.typography.headlineSmall
+            )
+        }
+
+        item {
             Spacer(Modifier.height(12.dp))
-            Text("Status: $status")
+
+            OutlinedTextField(
+                value = groupTitle,
+                onValueChange = { groupTitle = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Group name") },
+                singleLine = true,
+                enabled = !working
+            )
         }
 
+        item {
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = groupMembersInput,
+                onValueChange = { groupMembersInput = it },
+                modifier = Modifier.fillMaxWidth(),
+                label = { Text("Enter member UIDs, comma separated") },
+                enabled = !working
+            )
+        }
+
+        item {
+            Spacer(Modifier.height(12.dp))
+
+            Button(
+                enabled = groupTitle.trim().isNotEmpty() && !working && isSignedIn,
+                onClick = {
+                    scope.launch {
+                        try {
+                            working = true
+                            status = null
+
+                            val myUid = auth.currentUser?.uid
+                                ?: throw Exception("User not signed in")
+
+                            val otherMembers = groupMembersInput
+                                .split(",")
+                                .map { it.trim() }
+                                .filter { it.isNotBlank() }
+
+                            val allMembers = (listOf(myUid) + otherMembers).distinct()
+
+                            if (allMembers.size < 2) {
+                                throw Exception("Enter at least one other UID")
+                            }
+
+                            val newChatId = repo.openOrCreateGroupChat(
+                                createdBy = myUid,
+                                memberIds = allMembers,
+                                title = groupTitle.trim()
+                            )
+
+                            val actualTitle = repo.getChatTitle(newChatId)
+
+                            refreshChats()
+                            selectedChatId = newChatId
+                            selectedChatTitle = actualTitle
+
+                            groupTitle = ""
+                            groupMembersInput = ""
+
+                        } catch (e: Exception) {
+                            status = e.message ?: "Failed to create group"
+                        } finally {
+                            working = false
+                        }
+                    }
+                }
+            ) {
+                Text(if (working) "Working…" else "Create Group")
+            }
+        }
+
+        item {
         Spacer(Modifier.height(20.dp))
         HorizontalDivider()
         Spacer(Modifier.height(12.dp))
@@ -191,15 +297,17 @@ fun FriendsScreen(
             text = "Saved Chats",
             style = MaterialTheme.typography.headlineSmall
         )
+            }
 
+        item {
         Spacer(Modifier.height(8.dp))
+            }
 
         if (myChats.isEmpty()) {
-            Text("No chats yet.")
+            item {
+                Text("No chats yet.")
+            }
         } else {
-            LazyColumn(
-                modifier = Modifier.fillMaxWidth()
-            ) {
                 items(myChats, key = { it.id }) { chat ->
                     Card(
                         modifier = Modifier
@@ -268,4 +376,3 @@ fun FriendsScreen(
             }
         }
     }
-}

--- a/app/src/main/java/com/example/classseek/ui/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/friends/FriendsScreen.kt
@@ -147,7 +147,7 @@ fun FriendsScreen(
 
                         val targetUid = otherUid.trim()
                         val defaultTitle = "Chat ${myChats.size + 1}"
-                        val finalTitle = if (chatTitle.trim().isBlank()) {
+                        val firstTitle = if (chatTitle.trim().isBlank()) {
                             defaultTitle
                         } else {
                             chatTitle.trim()
@@ -156,8 +156,10 @@ fun FriendsScreen(
                         val createdChatId = repo.openOrCreateDm(
                             uidA = uid,
                             uidB = targetUid,
-                            title = finalTitle
+                            title = firstTitle
                         )
+
+                        val finalTitle = repo.getChatTitle(createdChatId)
 
                         refreshChats()
                         selectedChatId = createdChatId


### PR DESCRIPTION
I've made it so that chat names are consistent through out users. 

Users can now make group chats with as many users as needed. They all see the same messages and are updated in real time. 

Made it so that the saved chat cards also update in real time. Now if a user creates a chat with another user's UID on it, the chat will auto populate in the "Saved Chat" section. 

Changed chat layout to reverse layout so that the chat index follows a more understandable indexing pattern where the newest message is at the top. 

Implemented Seen/Sent status to the chats so that users can now see if their message has been read. It updates in real time so if a user leaves the chat it will display new messages as "sent" and not "seen". 

Fixed the initial state of the chat. Previously, when an already created chat was opened it would start from the very top of the chat history where the oldest message is at. Now, when opened, it will snap to the last read message. Also when typing a new message it will snap to the new message you just typed. 