### PR TITLE
Profile and Map Changes

### DIFF
--- a/app/src/main/java/com/example/classseek/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/ProfileScreen.kt
@@ -1179,9 +1179,12 @@ fun ScheduleSection(
                     val activeClasses = userProfile.classes.filter { it.className.isNotBlank() }
 
                     activeClasses.forEachIndexed { index, classInfo ->
-                        Column(modifier = Modifier.padding(vertical = 4.dp)) {
+                        Column(modifier = Modifier.fillMaxWidth()) {
                             Row(
-                                modifier = Modifier.fillMaxWidth(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .heightIn(min = 52.dp)
+                                    .padding(vertical = 10.dp),
                                 horizontalArrangement = Arrangement.SpaceBetween,
                                 verticalAlignment = Alignment.CenterVertically
                             ) {
@@ -1226,10 +1229,7 @@ fun ScheduleSection(
                             }
 
                             if (index != activeClasses.lastIndex) {
-                                HorizontalDivider(
-                                    modifier = Modifier.padding(vertical = 8.dp),
-                                    color = ProfileTheme.Border
-                                )
+                                HorizontalDivider(color = ProfileTheme.Border)
                             }
                         }
                     }

--- a/app/src/main/java/com/example/classseek/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/ProfileScreen.kt
@@ -1245,27 +1245,32 @@ fun BookmarkedEventsSection(
     events: List<Event>,
     onRemoveBookmark: (Event) -> Unit
 ) {
-    ProfileModuleSurface {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = "Bookmarked Events",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = ProfileTheme.Primary
-            )
+    var isExpanded by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("") }
 
-            Icon(
-                imageVector = Icons.Default.Bookmark,
-                contentDescription = null,
-                tint = Color.Gray
-            )
+    val normalizedQuery = searchQuery.trim()
+
+    val filteredEvents = if (normalizedQuery.isBlank()) {
+        events
+    } else {
+        events.filter { event ->
+            (event.summary ?: "").contains(normalizedQuery, ignoreCase = true) ||
+                    (event.location ?: "").contains(normalizedQuery, ignoreCase = true)
         }
+    }
 
-        Spacer(modifier = Modifier.height(8.dp))
+    val previewEvents = events.take(3)
+
+    SettingsSectionCard(title = "Bookmarked Events") {
+        if (isExpanded) {
+            SearchBar(
+                query = searchQuery,
+                onQueryChange = { searchQuery = it },
+                placeholder = "Search bookmarks"
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+        }
 
         if (events.isEmpty()) {
             Text(
@@ -1274,65 +1279,113 @@ fun BookmarkedEventsSection(
                 color = ProfileTheme.MutedForeground,
                 modifier = Modifier.padding(vertical = 8.dp)
             )
-        } else {
-            events.forEachIndexed { index, event ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(vertical = 8.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = event.summary ?: "(No Title)",
-                            style = MaterialTheme.typography.bodyLarge,
-                            fontWeight = FontWeight.SemiBold,
-                            color = ProfileTheme.Primary
-                        )
-
-                        val dateText = formatEventDate(event.start?.dateTime ?: event.start?.date)
-                        if (dateText.isNotEmpty()) {
-                            Text(
-                                text = dateText,
-                                style = MaterialTheme.typography.bodySmall,
-                                color = ProfileTheme.MutedForeground
-                            )
-                        }
-
-                        if (!event.location.isNullOrBlank()) {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(
-                                    imageVector = Icons.Default.LocationOn,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(14.dp),
-                                    tint = ProfileTheme.MutedForeground
-                                )
-                                Spacer(modifier = Modifier.width(4.dp))
-                                Text(
-                                    text = event.location,
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = ProfileTheme.MutedForeground,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                            }
-                        }
-                    }
-
-                    IconButton(onClick = { onRemoveBookmark(event) }) {
-                        Icon(
-                            imageVector = Icons.Default.Bookmark,
-                            contentDescription = "Remove Bookmark",
-                            tint = Color(0xFFFFD700)
-                        )
-                    }
-                }
-
-                if (index != events.lastIndex) {
+        } else if (isExpanded && filteredEvents.isEmpty()) {
+            Text(
+                text = "No matching events.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = ProfileTheme.MutedForeground,
+                modifier = Modifier.padding(vertical = 8.dp)
+            )
+        } else if (isExpanded) {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 400.dp)
+            ) {
+                items(filteredEvents) { event ->
+                    ProfileEventItem(
+                        event = event,
+                        onRemoveBookmark = { onRemoveBookmark(event) }
+                    )
                     HorizontalDivider(color = ProfileTheme.Border)
                 }
             }
+        } else {
+            previewEvents.forEachIndexed { index, event ->
+                ProfileEventItem(
+                    event = event,
+                    onRemoveBookmark = { onRemoveBookmark(event) }
+                )
+
+                if (index != previewEvents.lastIndex) {
+                    HorizontalDivider(color = ProfileTheme.Border)
+                }
+            }
+        }
+
+        if (events.size > 3) {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            TextButton(
+                onClick = {
+                    isExpanded = !isExpanded
+                    if (!isExpanded) {
+                        searchQuery = ""
+                    }
+                },
+                modifier = Modifier.align(Alignment.Start)
+            ) {
+                Text(if (isExpanded) "Show less" else "View all")
+            }
+        }
+    }
+}
+
+@Composable
+fun ProfileEventItem(
+    event: Event,
+    onRemoveBookmark: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = event.summary ?: "(No Title)",
+                style = MaterialTheme.typography.bodyLarge,
+                fontWeight = FontWeight.SemiBold,
+                color = ProfileTheme.Primary
+            )
+
+            val dateText = formatEventDate(event.start?.dateTime ?: event.start?.date)
+            if (dateText.isNotEmpty()) {
+                Text(
+                    text = dateText,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = ProfileTheme.MutedForeground
+                )
+            }
+
+            if (!event.location.isNullOrBlank()) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.LocationOn,
+                        contentDescription = null,
+                        modifier = Modifier.size(14.dp),
+                        tint = ProfileTheme.MutedForeground
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = event.location,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = ProfileTheme.MutedForeground,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+
+        IconButton(onClick = onRemoveBookmark) {
+            Icon(
+                imageVector = Icons.Default.Bookmark,
+                contentDescription = "Remove Bookmark",
+                tint = Color(0xFFFFD700)
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/classseek/ui/ProfileScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/ProfileScreen.kt
@@ -335,15 +335,12 @@ fun SettingsProfileScreen(
                         onCheckedChange = { onUpdateSettings(mapOf("showOnlineStatus" to it)) }
                     )
                     HorizontalDivider(color = ProfileTheme.Border)
-                    /*
                     SettingsSwitchRow(
                         title = "Location Sharing",
-                        subtitle = "Allow sharing location in chats",
+                        subtitle = "Allow location sharing on map",
                         checked = userProfile.shareLocation,
                         onCheckedChange = { onUpdateSettings(mapOf("shareLocation" to it)) }
                     )
-
-                     */
                     HorizontalDivider(color = ProfileTheme.Border)
                     Column(modifier = Modifier.padding(vertical = 12.dp)) {
                         Text("Profile Visibility", style = MaterialTheme.typography.titleSmall, color = ProfileTheme.Primary)
@@ -1137,15 +1134,17 @@ fun ScheduleSection(
                     onClick = onEditClick,
                     modifier = Modifier
                         .align(Alignment.TopEnd)
+                        .size(28.dp)
                         .background(
-                            MaterialTheme.colorScheme.surfaceVariant,
+                            MaterialTheme.colorScheme.secondaryContainer,
                             CircleShape
                         )
                 ) {
                     Icon(
                         Icons.Default.Edit,
                         contentDescription = "Edit Schedule",
-                        tint = ProfileTheme.MutedForeground
+                        modifier = Modifier.size(20.dp),
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer
                     )
                 }
             }

--- a/app/src/main/java/com/example/classseek/ui/ScheduleEditScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/ScheduleEditScreen.kt
@@ -190,19 +190,27 @@ fun ScheduleEditScreen(
                         }
                         Spacer(modifier = Modifier.height(8.dp))
 
-                        val daysList = listOf("M", "T", "W", "TH", "F", "SA", "SU")
+                        val daysMap = listOf(
+                            "SU" to "S",
+                            "M" to "M",
+                            "T" to "T",
+                            "W" to "W",
+                            "TH" to "T",
+                            "F" to "F",
+                            "SA" to "S"
+                        )
                         val selectedDays = classInfo.dayOfWeek.split(",").filter { it.isNotBlank() }.toMutableList()
 
                         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                            daysList.forEach { day ->
-                                val isSelected = selectedDays.contains(day)
+                            daysMap.forEach { (value, label) ->
+                                val isSelected = selectedDays.contains(value)
                                 FilterChip(
                                     selected = isSelected,
                                     onClick = {
-                                        if (isSelected) selectedDays.remove(day) else selectedDays.add(day)
+                                        if (isSelected) selectedDays.remove(value) else selectedDays.add(value)
                                         classes[index] = classInfo.copy(dayOfWeek = selectedDays.joinToString(","))
                                     },
-                                    label = { Text(day, fontSize = 9.sp) },
+                                    label = { Text(label, fontSize = 9.sp) },
                                     modifier = Modifier.weight(1f)
                                 )
                             }

--- a/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
@@ -818,7 +818,7 @@ fun MapScreen(
                         }
                     },
                     singleLine = true,
-                    shape = RoundedCornerShape(24.dp),
+                    shape = RoundedCornerShape(18.dp),
                     colors = TextFieldDefaults.colors(
                         focusedTextColor = Color.Black,
                         unfocusedTextColor = Color.Black,

--- a/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
@@ -109,6 +109,7 @@ fun MapScreen(
     val userProfiles = remember { mutableStateMapOf<String, UserProfile>() }
 
     var searchQuery by remember { mutableStateOf("") }
+    var showSuggestions by remember { mutableStateOf(false) }
     var selectedCategory by remember { mutableStateOf(MarkerCategory.ALL) }
     var isListVisible by remember { mutableStateOf(false) }
     var selectedPlace by remember { mutableStateOf<MapPlace?>(null) }
@@ -459,11 +460,15 @@ fun MapScreen(
 
             baseMarkers.forEach { place ->
                 val isSelected = selectedPlace?.name == place.name && selectedPlace?.location == place.location
-                val isInSelectedCategory = selectedCategory == MarkerCategory.ALL || place.category == selectedCategory
 
                 // Find events/classes at this specific location to show as badges
                 val classesHere = scheduleMarkers.filter { it.location == place.location }
                 val eventsHere = bookmarkMarkers.filter { it.location == place.location }
+
+                val isInSelectedCategory = selectedCategory == MarkerCategory.ALL ||
+                        place.category == selectedCategory ||
+                        (selectedCategory == MarkerCategory.CLASS && classesHere.isNotEmpty()) ||
+                        (selectedCategory == MarkerCategory.BOOKMARK && eventsHere.isNotEmpty())
 
                 val markerAlpha = if (selectedPlace != null) {
                     if (isSelected) 1.0f else 0.35f
@@ -795,26 +800,22 @@ fun MapScreen(
                     value = searchQuery,
                     onValueChange = { newValue ->
                         searchQuery = newValue
-                        allMarkers.find { it.name.contains(newValue, ignoreCase = true) }?.let { match ->
-                            // Resolve to base marker if a class or event is found
-                            val finalMatch = if (match.category == MarkerCategory.CLASS || match.category == MarkerCategory.BOOKMARK) {
-                                places.find { it.location == match.location } ?: match
-                            } else match
-
-                            selectedPlace = finalMatch
-                            scope.launch {
-                                if (isMapReady) {
-                                    cameraPositionState.animate(CameraUpdateFactory.newLatLngZoom(finalMatch.location, 18f))
-                                } else {
-                                    cameraPositionState.position = CameraPosition.fromLatLngZoom(finalMatch.location, 18f)
-                                }
-                            }
-                        }
+                        showSuggestions = newValue.isNotEmpty()
                     },
                     modifier = Modifier.weight(1f),
                     placeholder = { Text("Search facilities...") },
                     leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-                    trailingIcon = { if (searchQuery.isNotEmpty()) IconButton(onClick = { searchQuery = ""; selectedPlace = null }) { Icon(Icons.Default.Clear, contentDescription = "Clear") } },
+                    trailingIcon = {
+                        if (searchQuery.isNotEmpty()) {
+                            IconButton(onClick = {
+                                searchQuery = ""
+                                selectedPlace = null
+                                showSuggestions = false
+                            }) {
+                                Icon(Icons.Default.Clear, contentDescription = "Clear")
+                            }
+                        }
+                    },
                     singleLine = true,
                     shape = RoundedCornerShape(24.dp),
                     colors = TextFieldDefaults.colors(
@@ -890,6 +891,62 @@ fun MapScreen(
                     }
                 }
             }
+
+            // Search Suggestions Card
+            if (showSuggestions && searchQuery.isNotBlank()) {
+                val suggestions = allMarkers.filter {
+                    it.name.contains(searchQuery, ignoreCase = true) ||
+                    it.description.contains(searchQuery, ignoreCase = true)
+                }.take(5)
+
+                if (suggestions.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(end = 64.dp), // Align with search bar width (approx)
+                        shape = RoundedCornerShape(16.dp),
+                        elevation = CardDefaults.cardElevation(8.dp),
+                        colors = CardDefaults.cardColors(containerColor = Color.White.copy(alpha = 0.95f))
+                    ) {
+                        Column {
+                            suggestions.forEach { place ->
+                                ListItem(
+                                    headlineContent = { Text(place.name, style = MaterialTheme.typography.bodyMedium) },
+                                    supportingContent = { Text(place.category.label, style = MaterialTheme.typography.labelSmall) },
+                                    leadingContent = {
+                                        Icon(
+                                            imageVector = place.category.icon,
+                                            contentDescription = null,
+                                            tint = place.category.color,
+                                            modifier = Modifier.size(20.dp)
+                                        )
+                                    },
+                                    modifier = Modifier.clickable {
+                                        searchQuery = place.name
+                                        showSuggestions = false
+
+                                        // Resolve to base marker if a class or event is found
+                                        val finalMatch = if (place.category == MarkerCategory.CLASS || place.category == MarkerCategory.BOOKMARK) {
+                                            places.find { it.location == place.location } ?: place
+                                        } else place
+
+                                        selectedPlace = finalMatch
+                                        scope.launch {
+                                            if (isMapReady) {
+                                                cameraPositionState.animate(CameraUpdateFactory.newLatLngZoom(finalMatch.location, 18f))
+                                            } else {
+                                                cameraPositionState.position = CameraPosition.fromLatLngZoom(finalMatch.location, 18f)
+                                            }
+                                        }
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
 
             Spacer(Modifier.height(8.dp))
 

--- a/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
@@ -389,7 +389,7 @@ fun MapScreen(
             val locationRequest = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 5000).build()
             val locationCallback = object : LocationCallback() {
                 override fun onLocationResult(result: LocationResult) {
-                    if (userProfile?.shareLocation == false) return
+                    if (currentUserProfile?.shareLocation == false) return
 
                     result.lastLocation?.let { newLoc ->
                         location = newLoc
@@ -422,22 +422,27 @@ fun MapScreen(
             onMapClick = { selectedPlace = null }
         ) {
             val profilePicUrl = currentUserProfile?.profilePictureUrl
+            val userMarkerState = rememberMarkerState()
+
+            // Update user marker position when location changes
+            LaunchedEffect(location) {
+                location?.let {
+                    userMarkerState.position = LatLng(it.latitude, it.longitude)
+                }
+            }
+
+            // Fetch the bitmap whenever the profile picture URL changes
+            LaunchedEffect(profilePicUrl) {
+                if (!profilePicUrl.isNullOrBlank()) {
+                    userMarkerIcon = loadMarkerBitmap(context, profilePicUrl)
+                }
+            }
 
             // User Location Marker - only if location is available
-            location?.let { loc ->
-                val currentLatLng = LatLng(loc.latitude, loc.longitude)
-
-                // Fetch the bitmap whenever the profile picture URL changes
-                LaunchedEffect(profilePicUrl) {
-                    Log.d("MapScreen", "User profilePicUrl updated in MapScreen: '$profilePicUrl'")
-                    if (!profilePicUrl.isNullOrBlank()) {
-                        userMarkerIcon = loadMarkerBitmap(context, profilePicUrl)
-                    }
-                }
-
-                // Only draw the marker once the icon is ready OR use a fallback
+            if (location != null) {
+                val currentLatLng = LatLng(location!!.latitude, location!!.longitude)
                 Marker(
-                    state = rememberMarkerState(position = currentLatLng),
+                    state = userMarkerState,
                     icon = userMarkerIcon ?: com.google.android.gms.maps.model.BitmapDescriptorFactory.defaultMarker(),
                     anchor = Offset(0.5f, 0.5f),
                     title = "My Location",
@@ -483,81 +488,88 @@ fun MapScreen(
                             }
                         )
                     } else {
+                        // Separate unclickable marker for the name label
                         MarkerComposable(
                             state = rememberMarkerState(position = place.location),
                             alpha = markerAlpha,
-                            anchor = Offset(0.5f, 1.0f),
+                            anchor = Offset(0.5f, 2.4f), // Positioned above the icon
+                            onClick = { false } // Clicks on the name do not select the building
+                        ) {
+                            Surface(
+                                shape = RoundedCornerShape(3.3.dp),
+                                color = Color.White.copy(alpha = if (isSelected) 0.95f else 0.85f),
+                            ) {
+                                Text(
+                                    text = place.name,
+                                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
+                                    modifier = Modifier.padding(horizontal = 3.6.dp, vertical = 1.5.dp),
+                                    color = Color.Black
+                                )
+                            }
+                        }
+
+                        // Clickable marker for the icon and badges
+                        MarkerComposable(
+                            state = rememberMarkerState(position = place.location),
+                            alpha = markerAlpha,
+                            anchor = Offset(0.5f, 0.96f), // Adjusted for padding
                             onClick = {
                                 selectedPlace = place
                                 true
                             }
                         ) {
-                            Box(contentAlignment = Alignment.Center) {
-                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                    Surface(
-                                        shape = RoundedCornerShape(3.3.dp),
-                                        color = Color.White.copy(alpha = if (isSelected) 0.95f else 0.85f),
-                                        modifier = Modifier.padding(bottom = 1.4.dp)
+                            Box(
+                                contentAlignment = Alignment.Center,
+                                modifier = Modifier.padding(horizontal = 7.dp, vertical = 0.dp)
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .background(Color.White, CircleShape)
+                                        .border(2.dp, place.category.color, CircleShape)
+                                        .padding(3.dp)
+                                ) {
+                                    Icon(
+                                        imageVector = place.category.icon,
+                                        contentDescription = null,
+                                        tint = place.category.color,
+                                        modifier = Modifier.size(19.8.dp)
+                                    )
+                                }
+
+                                // Overlay badges for Classes (Right) and Events (Left)
+                                if (classesHere.isNotEmpty()) {
+                                    Box(
+                                        modifier = Modifier
+                                            .align(Alignment.BottomEnd)
+                                            .offset(x = 7.dp, y = 0.dp)
+                                            .background(Color.White, CircleShape)
+                                            .border(1.dp, MarkerCategory.CLASS.color, CircleShape)
+                                            .padding(2.dp)
                                     ) {
-                                        Text(
-                                            text = place.name,
-                                            style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
-                                            modifier = Modifier.padding(horizontal = 3.6.dp, vertical = 1.5.dp),
-                                            color = Color.Black
+                                        Icon(
+                                            imageVector = MarkerCategory.CLASS.icon,
+                                            contentDescription = null,
+                                            tint = MarkerCategory.CLASS.color,
+                                            modifier = Modifier.size(10.dp)
                                         )
                                     }
+                                }
 
-                                    Box(contentAlignment = Alignment.Center) {
-                                        Box(
-                                            modifier = Modifier
-                                                .background(Color.White, CircleShape)
-                                                .border(2.dp, place.category.color, CircleShape)
-                                                .padding(3.dp)
-                                        ) {
-                                            Icon(
-                                                imageVector = place.category.icon,
-                                                contentDescription = null,
-                                                tint = place.category.color,
-                                                modifier = Modifier.size(19.8.dp)
-                                            )
-                                        }
-
-                                        // Overlay badges for Classes (Right) and Events (Left)
-                                        if (classesHere.isNotEmpty()) {
-                                            Box(
-                                                modifier = Modifier
-                                                    .align(Alignment.BottomEnd)
-                                                    .offset(x = 1.dp, y = 0.dp)
-                                                    .background(Color.White, CircleShape)
-                                                    .border(1.dp, MarkerCategory.CLASS.color, CircleShape)
-                                                    .padding(2.dp)
-                                            ) {
-                                                Icon(
-                                                    imageVector = MarkerCategory.CLASS.icon,
-                                                    contentDescription = null,
-                                                    tint = MarkerCategory.CLASS.color,
-                                                    modifier = Modifier.size(10.dp)
-                                                )
-                                            }
-                                        }
-
-                                        if (eventsHere.isNotEmpty()) {
-                                            Box(
-                                                modifier = Modifier
-                                                    .align(if (classesHere.isNotEmpty()) Alignment.BottomStart else Alignment.BottomEnd)
-                                                    .offset(x = if (classesHere.isNotEmpty()) (-1).dp else 1.dp, y = 0.dp)
-                                                    .background(Color.White, CircleShape)
-                                                    .border(1.dp, MarkerCategory.BOOKMARK.color, CircleShape)
-                                                    .padding(2.dp)
-                                            ) {
-                                                Icon(
-                                                    imageVector = MarkerCategory.BOOKMARK.icon,
-                                                    contentDescription = null,
-                                                    tint = MarkerCategory.BOOKMARK.color,
-                                                    modifier = Modifier.size(10.dp)
-                                                )
-                                            }
-                                        }
+                                if (eventsHere.isNotEmpty()) {
+                                    Box(
+                                        modifier = Modifier
+                                            .align(if (classesHere.isNotEmpty()) Alignment.BottomStart else Alignment.BottomEnd)
+                                            .offset(x = if (classesHere.isNotEmpty()) (-7).dp else 7.dp, y = 0.dp)
+                                            .background(Color.White, CircleShape)
+                                            .border(1.dp, MarkerCategory.BOOKMARK.color, CircleShape)
+                                            .padding(2.dp)
+                                    ) {
+                                        Icon(
+                                            imageVector = MarkerCategory.BOOKMARK.icon,
+                                            contentDescription = null,
+                                            tint = MarkerCategory.BOOKMARK.color,
+                                            modifier = Modifier.size(10.dp)
+                                        )
                                     }
                                 }
                             }

--- a/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
@@ -448,29 +448,17 @@ fun MapScreen(
                 )
             }
 
-            allMarkers.forEach { place ->
+            // Filter to show only base locations (buildings, services, shared, etc.)
+            // Events and Classes will be badges on these markers.
+            val baseMarkers = allMarkers.filter { it.category != MarkerCategory.CLASS && it.category != MarkerCategory.BOOKMARK }
+
+            baseMarkers.forEach { place ->
                 val isSelected = selectedPlace?.name == place.name && selectedPlace?.location == place.location
                 val isInSelectedCategory = selectedCategory == MarkerCategory.ALL || place.category == selectedCategory
 
-                // Logic to hide location markers if overlapped by specific categories (Bookmarks, Classes)
-                val hasOverlappingMarker = remember(place, bookmarkMarkers, scheduleMarkers) {
-                    if (place.category == MarkerCategory.BUILDING ||
-                        place.category == MarkerCategory.STUDENT_SERVICE ||
-                        place.category == MarkerCategory.DINING) {
-                        bookmarkMarkers.any { it.location == place.location } ||
-                                scheduleMarkers.any { it.location == place.location }
-                    } else false
-                }
-
-                // Hide building/service name if overlapped, unless filter active or specifically selected
-                val shouldShowName = if (hasOverlappingMarker) {
-                    selectedCategory == place.category || isSelected
-                } else true
-
-                // Hide building/service icon if overlapped, unless category filter used or specifically selected/searched
-                val shouldShowBuildingIcon = if (hasOverlappingMarker) {
-                    selectedCategory == place.category || isSelected
-                } else true
+                // Find events/classes at this specific location to show as badges
+                val classesHere = scheduleMarkers.filter { it.location == place.location }
+                val eventsHere = bookmarkMarkers.filter { it.location == place.location }
 
                 val markerAlpha = if (selectedPlace != null) {
                     if (isSelected) 1.0f else 0.35f
@@ -480,59 +468,96 @@ fun MapScreen(
                     1.0f
                 }
 
-                if (shouldShowBuildingIcon) {
-                    key("${place.name}_${place.location.latitude}_${place.location.longitude}_${place.category}") {
-                        if (place.category == MarkerCategory.SHARED && place.senderId != null) {
-                            val icon = sharedMarkerIcons[place.senderId]
-                            Marker(
-                                state = rememberMarkerState(position = place.location),
-                                icon = icon ?: com.google.android.gms.maps.model.BitmapDescriptorFactory.defaultMarker(),
-                                alpha = markerAlpha,
-                                anchor = Offset(0.5f, 0.5f),
-                                title = place.name,
-                                onClick = {
-                                    selectedPlace = place
-                                    true
-                                }
-                            )
-                        } else {
-                            MarkerComposable(
-                                state = rememberMarkerState(position = place.location),
-                                alpha = markerAlpha,
-                                anchor = Offset(0.5f, 1.0f),
-                                onClick = {
-                                    selectedPlace = place
-                                    true
-                                }
-                            ) {
+                key("${place.name}_${place.location.latitude}_${place.location.longitude}_${place.category}") {
+                    if (place.category == MarkerCategory.SHARED && place.senderId != null) {
+                        val icon = sharedMarkerIcons[place.senderId]
+                        Marker(
+                            state = rememberMarkerState(position = place.location),
+                            icon = icon ?: com.google.android.gms.maps.model.BitmapDescriptorFactory.defaultMarker(),
+                            alpha = markerAlpha,
+                            anchor = Offset(0.5f, 0.5f),
+                            title = place.name,
+                            onClick = {
+                                selectedPlace = place
+                                true
+                            }
+                        )
+                    } else {
+                        MarkerComposable(
+                            state = rememberMarkerState(position = place.location),
+                            alpha = markerAlpha,
+                            anchor = Offset(0.5f, 1.0f),
+                            onClick = {
+                                selectedPlace = place
+                                true
+                            }
+                        ) {
+                            Box(contentAlignment = Alignment.Center) {
                                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                    if (shouldShowName) {
-                                        Surface(
-                                            shape = RoundedCornerShape(3.3.dp),
-                                            color = Color.White.copy(alpha = if (isSelected) 0.95f else 0.85f),
-                                            modifier = Modifier.padding(bottom = 1.4.dp)
-                                        ) {
-                                            Text(
-                                                text = place.name,
-                                                style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
-                                                modifier = Modifier.padding(horizontal = 3.6.dp, vertical = 1.5.dp),
-                                                color = Color.Black
-                                            )
-                                        }
+                                    Surface(
+                                        shape = RoundedCornerShape(3.3.dp),
+                                        color = Color.White.copy(alpha = if (isSelected) 0.95f else 0.85f),
+                                        modifier = Modifier.padding(bottom = 1.4.dp)
+                                    ) {
+                                        Text(
+                                            text = place.name,
+                                            style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
+                                            modifier = Modifier.padding(horizontal = 3.6.dp, vertical = 1.5.dp),
+                                            color = Color.Black
+                                        )
                                     }
 
-                                    Box(
-                                        modifier = Modifier
-                                            .background(Color.White, CircleShape)
-                                            .border(2.dp, place.category.color, CircleShape)
-                                            .padding(3.dp)
-                                    ) {
-                                        Icon(
-                                            imageVector = place.category.icon,
-                                            contentDescription = null,
-                                            tint = place.category.color,
-                                            modifier = Modifier.size(if (place.category == MarkerCategory.CLASS) 14.dp else 19.8.dp)
-                                        )
+                                    Box(contentAlignment = Alignment.Center) {
+                                        Box(
+                                            modifier = Modifier
+                                                .background(Color.White, CircleShape)
+                                                .border(2.dp, place.category.color, CircleShape)
+                                                .padding(3.dp)
+                                        ) {
+                                            Icon(
+                                                imageVector = place.category.icon,
+                                                contentDescription = null,
+                                                tint = place.category.color,
+                                                modifier = Modifier.size(19.8.dp)
+                                            )
+                                        }
+
+                                        // Overlay badges for Classes (Right) and Events (Left)
+                                        if (classesHere.isNotEmpty()) {
+                                            Box(
+                                                modifier = Modifier
+                                                    .align(Alignment.BottomEnd)
+                                                    .offset(x = 1.dp, y = 0.dp)
+                                                    .background(Color.White, CircleShape)
+                                                    .border(1.dp, MarkerCategory.CLASS.color, CircleShape)
+                                                    .padding(2.dp)
+                                            ) {
+                                                Icon(
+                                                    imageVector = MarkerCategory.CLASS.icon,
+                                                    contentDescription = null,
+                                                    tint = MarkerCategory.CLASS.color,
+                                                    modifier = Modifier.size(10.dp)
+                                                )
+                                            }
+                                        }
+
+                                        if (eventsHere.isNotEmpty()) {
+                                            Box(
+                                                modifier = Modifier
+                                                    .align(if (classesHere.isNotEmpty()) Alignment.BottomStart else Alignment.BottomEnd)
+                                                    .offset(x = if (classesHere.isNotEmpty()) (-1).dp else 1.dp, y = 0.dp)
+                                                    .background(Color.White, CircleShape)
+                                                    .border(1.dp, MarkerCategory.BOOKMARK.color, CircleShape)
+                                                    .padding(2.dp)
+                                            ) {
+                                                Icon(
+                                                    imageVector = MarkerCategory.BOOKMARK.icon,
+                                                    contentDescription = null,
+                                                    tint = MarkerCategory.BOOKMARK.color,
+                                                    modifier = Modifier.size(10.dp)
+                                                )
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -579,6 +604,36 @@ fun MapScreen(
                             }
                         } else if (place.description.isNotEmpty()) {
                             Text(text = place.description, style = MaterialTheme.typography.bodySmall)
+                        }
+
+                        // Add section for classes and events at this location
+                        val classesHere = remember(place, scheduleMarkers) { scheduleMarkers.filter { it.location == place.location } }
+                        val eventsHere = remember(place, bookmarkMarkers, classesHere) {
+                            bookmarkMarkers.filter { it.location == place.location }
+                                .filter { event -> classesHere.none { it.name == event.name } }
+                        }
+
+                        if (classesHere.isNotEmpty() || eventsHere.isNotEmpty()) {
+                            Spacer(Modifier.height(2.dp))
+                            if (classesHere.isNotEmpty()) {
+                                Text("Classes:", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, color = MarkerCategory.CLASS.color)
+                                classesHere.forEach { cls ->
+                                    Text(
+                                        text = "• ${cls.name}${if (!cls.eventStart.isNullOrBlank()) " (${cls.eventStart})" else ""}",
+                                        style = MaterialTheme.typography.bodySmall
+                                    )
+                                }
+                            }
+                            if (eventsHere.isNotEmpty()) {
+                                if (classesHere.isNotEmpty()) Spacer(Modifier.height(2.dp))
+                                Text("Events:", style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold, color = MarkerCategory.BOOKMARK.color)
+                                eventsHere.forEach { ev ->
+                                    Text(
+                                        text = "• ${ev.name}${if (!ev.eventStart.isNullOrBlank()) " (${ev.eventStart})" else ""}",
+                                        style = MaterialTheme.typography.bodySmall
+                                    )
+                                }
+                            }
                         }
                     }
                     Button(onClick = { showShareDialog = true }) {
@@ -729,12 +784,17 @@ fun MapScreen(
                     onValueChange = { newValue ->
                         searchQuery = newValue
                         allMarkers.find { it.name.contains(newValue, ignoreCase = true) }?.let { match ->
-                            selectedPlace = match
+                            // Resolve to base marker if a class or event is found
+                            val finalMatch = if (match.category == MarkerCategory.CLASS || match.category == MarkerCategory.BOOKMARK) {
+                                places.find { it.location == match.location } ?: match
+                            } else match
+
+                            selectedPlace = finalMatch
                             scope.launch {
                                 if (isMapReady) {
-                                    cameraPositionState.animate(CameraUpdateFactory.newLatLngZoom(match.location, 18f))
+                                    cameraPositionState.animate(CameraUpdateFactory.newLatLngZoom(finalMatch.location, 18f))
                                 } else {
-                                    cameraPositionState.position = CameraPosition.fromLatLngZoom(match.location, 18f)
+                                    cameraPositionState.position = CameraPosition.fromLatLngZoom(finalMatch.location, 18f)
                                 }
                             }
                         }
@@ -888,14 +948,19 @@ fun MapScreen(
                                         },
                                         modifier = Modifier.clickable {
                                             scope.launch {
-                                                selectedPlace = place
+                                                // Resolve to base marker if a class or event is clicked in list
+                                                val finalPlace = if (place.category == MarkerCategory.CLASS || place.category == MarkerCategory.BOOKMARK) {
+                                                    places.find { it.location == place.location } ?: place
+                                                } else place
+
+                                                selectedPlace = finalPlace
                                                 if (isMapReady) {
                                                     cameraPositionState.animate(
-                                                        update = CameraUpdateFactory.newLatLngZoom(place.location, 18f),
+                                                        update = CameraUpdateFactory.newLatLngZoom(finalPlace.location, 18f),
                                                         durationMs = 1000
                                                     )
                                                 } else {
-                                                    cameraPositionState.position = CameraPosition.fromLatLngZoom(place.location, 18f)
+                                                    cameraPositionState.position = CameraPosition.fromLatLngZoom(finalPlace.location, 18f)
                                                 }
                                             }
                                             isListVisible = false

--- a/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
@@ -950,7 +950,7 @@ fun MapScreen(
 
             Spacer(Modifier.height(8.dp))
 
-            if (hasPermission) {
+            if (hasPermission && userProfile?.shareLocation != false) {
                 FloatingActionButton(
                     onClick = {
                         if (location != null) {

--- a/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/example/classseek/ui/map/MapScreen.kt
@@ -406,25 +406,26 @@ fun MapScreen(
 
     // Box to put the map and search bar on
     Box(modifier = modifier.fillMaxSize()) {
-        if (hasPermission && location != null) {
-            val currentLatLng = LatLng(location!!.latitude, location!!.longitude)
+        GoogleMap(
+            modifier = Modifier.fillMaxSize(),
+            cameraPositionState = cameraPositionState,
+            onMapLoaded = { isMapReady = true },
+            properties = MapProperties(
+                mapType = mapType,
+                latLngBoundsForCameraTarget = bounds,
+                minZoomPreference = 14.5f,
+                mapStyleOptions = MapStyleOptions(
+                    if (isDarkTheme) darkMapStyleJson else lightMapStyleJson
+                )
+            ),
+            uiSettings = MapUiSettings(mapToolbarEnabled = false),
+            onMapClick = { selectedPlace = null }
+        ) {
+            val profilePicUrl = currentUserProfile?.profilePictureUrl
 
-            GoogleMap(
-                modifier = Modifier.fillMaxSize(),
-                cameraPositionState = cameraPositionState,
-                onMapLoaded = { isMapReady = true },
-                properties = MapProperties(
-                    mapType = mapType,
-                    latLngBoundsForCameraTarget = bounds,
-                    minZoomPreference = 14.5f,
-                    mapStyleOptions = MapStyleOptions(
-                        if (isDarkTheme) darkMapStyleJson else lightMapStyleJson
-                    )
-                ),
-                uiSettings = MapUiSettings(mapToolbarEnabled = false),
-                onMapClick = { selectedPlace = null }
-            ) {
-                val profilePicUrl = currentUserProfile?.profilePictureUrl
+            // User Location Marker - only if location is available
+            location?.let { loc ->
+                val currentLatLng = LatLng(loc.latitude, loc.longitude)
 
                 // Fetch the bitmap whenever the profile picture URL changes
                 LaunchedEffect(profilePicUrl) {
@@ -445,93 +446,93 @@ fun MapScreen(
                         true
                     }
                 )
+            }
 
-                allMarkers.forEach { place ->
-                    val isSelected = selectedPlace?.name == place.name && selectedPlace?.location == place.location
-                    val isInSelectedCategory = selectedCategory == MarkerCategory.ALL || place.category == selectedCategory
+            allMarkers.forEach { place ->
+                val isSelected = selectedPlace?.name == place.name && selectedPlace?.location == place.location
+                val isInSelectedCategory = selectedCategory == MarkerCategory.ALL || place.category == selectedCategory
 
-                    // Logic to hide location markers if overlapped by specific categories (Bookmarks, Classes)
-                    val hasOverlappingMarker = remember(place, bookmarkMarkers, scheduleMarkers) {
-                        if (place.category == MarkerCategory.BUILDING ||
-                            place.category == MarkerCategory.STUDENT_SERVICE ||
-                            place.category == MarkerCategory.DINING) {
-                            bookmarkMarkers.any { it.location == place.location } ||
-                                    scheduleMarkers.any { it.location == place.location }
-                        } else false
-                    }
+                // Logic to hide location markers if overlapped by specific categories (Bookmarks, Classes)
+                val hasOverlappingMarker = remember(place, bookmarkMarkers, scheduleMarkers) {
+                    if (place.category == MarkerCategory.BUILDING ||
+                        place.category == MarkerCategory.STUDENT_SERVICE ||
+                        place.category == MarkerCategory.DINING) {
+                        bookmarkMarkers.any { it.location == place.location } ||
+                                scheduleMarkers.any { it.location == place.location }
+                    } else false
+                }
 
-                    // Hide building/service name if overlapped, unless filter active or specifically selected
-                    val shouldShowName = if (hasOverlappingMarker) {
-                        selectedCategory == place.category || isSelected
-                    } else true
+                // Hide building/service name if overlapped, unless filter active or specifically selected
+                val shouldShowName = if (hasOverlappingMarker) {
+                    selectedCategory == place.category || isSelected
+                } else true
 
-                    // Hide building/service icon if overlapped, unless category filter used or specifically selected/searched
-                    val shouldShowBuildingIcon = if (hasOverlappingMarker) {
-                        selectedCategory == place.category || isSelected
-                    } else true
+                // Hide building/service icon if overlapped, unless category filter used or specifically selected/searched
+                val shouldShowBuildingIcon = if (hasOverlappingMarker) {
+                    selectedCategory == place.category || isSelected
+                } else true
 
-                    val markerAlpha = if (selectedPlace != null) {
-                        if (isSelected) 1.0f else 0.35f
-                    } else if (selectedCategory != MarkerCategory.ALL) {
-                        if (isInSelectedCategory) 1.0f else 0.35f
-                    } else {
-                        1.0f
-                    }
+                val markerAlpha = if (selectedPlace != null) {
+                    if (isSelected) 1.0f else 0.35f
+                } else if (selectedCategory != MarkerCategory.ALL) {
+                    if (isInSelectedCategory) 1.0f else 0.35f
+                } else {
+                    1.0f
+                }
 
-                    if (shouldShowBuildingIcon) {
-                        key("${place.name}_${place.location.latitude}_${place.location.longitude}_${place.category}") {
-                            if (place.category == MarkerCategory.SHARED && place.senderId != null) {
-                                val icon = sharedMarkerIcons[place.senderId]
-                                Marker(
-                                    state = rememberMarkerState(position = place.location),
-                                    icon = icon ?: com.google.android.gms.maps.model.BitmapDescriptorFactory.defaultMarker(),
-                                    alpha = markerAlpha,
-                                    anchor = Offset(0.5f, 0.5f),
-                                    title = place.name,
-                                    onClick = {
-                                        selectedPlace = place
-                                        true
-                                    }
-                                )
-                            } else {
-                                MarkerComposable(
-                                    state = rememberMarkerState(position = place.location),
-                                    alpha = markerAlpha,
-                                    anchor = Offset(0.5f, 1.0f),
-                                    onClick = {
-                                        selectedPlace = place
-                                        true
-                                    }
-                                ) {
-                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                        if (shouldShowName) {
-                                            Surface(
-                                                shape = RoundedCornerShape(3.3.dp),
-                                                color = Color.White.copy(alpha = if (isSelected) 0.95f else 0.85f),
-                                                modifier = Modifier.padding(bottom = 1.4.dp)
-                                            ) {
-                                                Text(
-                                                    text = place.name,
-                                                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
-                                                    modifier = Modifier.padding(horizontal = 3.6.dp, vertical = 1.5.dp),
-                                                    color = Color.Black
-                                                )
-                                            }
-                                        }
-
-                                        Box(
-                                            modifier = Modifier
-                                                .background(Color.White, CircleShape)
-                                                .border(2.dp, place.category.color, CircleShape)
-                                                .padding(3.dp)
+                if (shouldShowBuildingIcon) {
+                    key("${place.name}_${place.location.latitude}_${place.location.longitude}_${place.category}") {
+                        if (place.category == MarkerCategory.SHARED && place.senderId != null) {
+                            val icon = sharedMarkerIcons[place.senderId]
+                            Marker(
+                                state = rememberMarkerState(position = place.location),
+                                icon = icon ?: com.google.android.gms.maps.model.BitmapDescriptorFactory.defaultMarker(),
+                                alpha = markerAlpha,
+                                anchor = Offset(0.5f, 0.5f),
+                                title = place.name,
+                                onClick = {
+                                    selectedPlace = place
+                                    true
+                                }
+                            )
+                        } else {
+                            MarkerComposable(
+                                state = rememberMarkerState(position = place.location),
+                                alpha = markerAlpha,
+                                anchor = Offset(0.5f, 1.0f),
+                                onClick = {
+                                    selectedPlace = place
+                                    true
+                                }
+                            ) {
+                                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                    if (shouldShowName) {
+                                        Surface(
+                                            shape = RoundedCornerShape(3.3.dp),
+                                            color = Color.White.copy(alpha = if (isSelected) 0.95f else 0.85f),
+                                            modifier = Modifier.padding(bottom = 1.4.dp)
                                         ) {
-                                            Icon(
-                                                imageVector = place.category.icon,
-                                                contentDescription = null,
-                                                tint = place.category.color,
-                                                modifier = Modifier.size(if (place.category == MarkerCategory.CLASS) 14.dp else 19.8.dp)
+                                            Text(
+                                                text = place.name,
+                                                style = MaterialTheme.typography.labelSmall.copy(fontSize = 8.sp),
+                                                modifier = Modifier.padding(horizontal = 3.6.dp, vertical = 1.5.dp),
+                                                color = Color.Black
                                             )
                                         }
+                                    }
+
+                                    Box(
+                                        modifier = Modifier
+                                            .background(Color.White, CircleShape)
+                                            .border(2.dp, place.category.color, CircleShape)
+                                            .padding(3.dp)
+                                    ) {
+                                        Icon(
+                                            imageVector = place.category.icon,
+                                            contentDescription = null,
+                                            tint = place.category.color,
+                                            modifier = Modifier.size(if (place.category == MarkerCategory.CLASS) 14.dp else 19.8.dp)
+                                        )
                                     }
                                 }
                             }
@@ -539,10 +540,6 @@ fun MapScreen(
                     }
                 }
             }
-        } else if (!hasPermission) {
-            Text("Location permission required.", Modifier.align(Alignment.Center))
-        } else {
-            Text("Fetching live location...", Modifier.align(Alignment.Center))
         }
 
         selectedPlace?.let { place ->
@@ -824,19 +821,21 @@ fun MapScreen(
 
             Spacer(Modifier.height(8.dp))
 
-            FloatingActionButton(
-                onClick = {
-                    if (location != null) {
-                        selectedPlace = MapPlace("Current Location", LatLng(location!!.latitude, location!!.longitude), MarkerCategory.SHARED, "Share your live location")
-                        showShareDialog = true
-                    }
-                },
-                modifier = Modifier.size(48.dp),
-                containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
-                contentColor = Color.White,
-                shape = RoundedCornerShape(12.dp)
-            ) {
-                Icon(Icons.Default.MyLocation, contentDescription = "Share Current Location")
+            if (hasPermission) {
+                FloatingActionButton(
+                    onClick = {
+                        if (location != null) {
+                            selectedPlace = MapPlace("Current Location", LatLng(location!!.latitude, location!!.longitude), MarkerCategory.SHARED, "Share your live location")
+                            showShareDialog = true
+                        }
+                    },
+                    modifier = Modifier.size(48.dp),
+                    containerColor = MaterialTheme.colorScheme.primary.copy(alpha = 0.9f),
+                    contentColor = Color.White,
+                    shape = RoundedCornerShape(12.dp)
+                ) {
+                    Icon(Icons.Default.MyLocation, contentDescription = "Share Current Location")
+                }
             }
         }
 


### PR DESCRIPTION
Made class/event markers a tag on the building marker itself, and the info is now stored in the share events popup.
Current Schedule now has consistent spacing.
Bookmarked events on Profile has a view all button and a search bar.
Text auto-fill on the map replaced the auto-scroll towards it.
Map now loads regardless of location permission. And disable location in settings is brought back.
Map marker hitboxes are slimmed (I wish I could do it more, but the border spacing is required because of how I built the composables)
Date selection formatting issue fixed.
Current Schedule edit button changed, let me know if you want it changed more.